### PR TITLE
Add basic workplace platform prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-readme
-# Dash
+# Dash Workplace Platform
+
+This is a prototype of a browser based productivity platform. It exposes multiple modules (Messaging, CRM, Project management, Timesheets and Leave) within a single interface. Each module is accessible via tabs.
+
+## Running locally
+
+1. Install dependencies: `npm install`
+2. Start the server: `node server.js`
+3. Open [http://localhost:3000](http://localhost:3000) in a browser.
+
+The prototype uses a simple Node/Express server to serve static files under `public/`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dash",
+  "version": "1.0.0",
+  "description": "readme # Dash",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,55 @@
+// app.js handles switching between modules and populating the sidebar and main
+// content areas. In a more advanced implementation these would likely be
+// separate React components or similar, but for demonstration purposes we
+// keep it lightweight with vanilla JavaScript.
+
+// Definitions for each module's sidebar and main content
+const modules = {
+    messaging: {
+        sidebar: ['Inbox', 'Sent', 'Drafts'],
+        content: 'Welcome to Messaging. Communicate instantly with coworkers.'
+    },
+    crm: {
+        sidebar: ['Leads', 'Opportunities', 'Accounts'],
+        content: 'Manage customer relationships in one place.'
+    },
+    projects: {
+        sidebar: ['Active Projects', 'Teams', 'Reports'],
+        content: 'Track project progress and collaborate.'
+    },
+    timesheets: {
+        sidebar: ['Submit Time', 'Review', 'Reports'],
+        content: 'Log hours and track billable time.'
+    },
+    leave: {
+        sidebar: ['Request Leave', 'Calendar', 'Approvals'],
+        content: 'Manage vacation and leave requests.'
+    }
+};
+
+const tabs = document.querySelectorAll('#tabs li');
+const sidebar = document.getElementById('sidebar');
+const main = document.getElementById('main-content');
+
+function renderModule(name) {
+    // Update active tab
+    tabs.forEach(tab => tab.classList.remove('active'));
+    document.querySelector(`#tabs li[data-module="${name}"]`).classList.add('active');
+
+    // Populate sidebar links
+    sidebar.innerHTML = '<ul>' + modules[name].sidebar.map(item => `<li>${item}</li>`).join('') + '</ul>';
+
+    // Populate main content
+    main.textContent = modules[name].content;
+}
+
+// Attach click handlers to each tab
+tabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+        const moduleName = tab.getAttribute('data-module');
+        renderModule(moduleName);
+    });
+});
+
+// Render default module on initial load
+renderModule('messaging');

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dash Workplace Platform</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <!-- Header contains tabs for each module -->
+    <header id="app-header">
+        <nav>
+            <ul id="tabs">
+                <li data-module="messaging" class="active">Messaging</li>
+                <li data-module="crm">CRM</li>
+                <li data-module="projects">Projects</li>
+                <li data-module="timesheets">Timesheets</li>
+                <li data-module="leave">Leave</li>
+            </ul>
+        </nav>
+    </header>
+
+    <!-- Sidebar changes with selected module -->
+    <aside id="sidebar"></aside>
+
+    <!-- Main content area -->
+    <main id="main-content"></main>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,57 @@
+/* Basic styling for the platform */
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    height: 100vh;
+    flex-direction: column;
+}
+
+header {
+    background-color: #2c3e50;
+    color: #ecf0f1;
+    padding: 10px;
+}
+
+#tabs {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+}
+
+#tabs li {
+    margin-right: 20px;
+    cursor: pointer;
+}
+
+#tabs li.active {
+    font-weight: bold;
+    text-decoration: underline;
+}
+
+main {
+    flex: 1;
+    padding: 20px;
+}
+
+aside {
+    width: 200px;
+    background-color: #ecf0f1;
+    padding: 20px;
+}
+
+/* Layout for sidebar + main content */
+body {
+    display: grid;
+    grid-template-rows: auto 1fr;
+    grid-template-columns: 200px 1fr;
+    grid-template-areas:
+        "header header"
+        "sidebar main";
+}
+
+header { grid-area: header; }
+aside { grid-area: sidebar; }
+main { grid-area: main; }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Serve static files from the public directory
+app.use(express.static(path.join(__dirname, 'public')));
+
+// Basic route just to verify server works
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- prototype for a tabbed workplace platform in `public/`
- simple Node/Express server to serve static content
- sample modules for messaging, CRM, projects, timesheets, leave
- instructions for running locally

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_686e6f254d448328983e0f7bb75de66f