### PR TITLE
Fix frontend API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Dash is an example enterprise web platform demonstrating several features:
    ```bash
    npx serve frontend
    ```
+   The JavaScript code assumes the API is available on `http://localhost:3000`.
+   If your backend runs elsewhere, update `API_BASE_URL` in
+   `frontend/js/app.js` accordingly so requests reach the correct server.
 
 ### Docker
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,10 +1,18 @@
+// Base URL for API requests. If the frontend is served from the same
+// port as the backend (e.g. both on port 3000), leave this empty so
+// all requests use the current origin. Otherwise, point to the backend
+// explicitly. Adjust the URL if your backend runs elsewhere.
+const API_BASE_URL = window.location.port === '3000' ? '' : 'http://localhost:3000';
+
 let currentUser = null;
 
 function login() {
   const username = document.getElementById('username').value;
   const password = document.getElementById('password').value;
 
-  fetch('/api/auth/login', {
+  // Use the API base URL for all requests so the frontend works even
+  // when served on a different port from the backend.
+  fetch(`${API_BASE_URL}/api/auth/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username, password })
@@ -22,7 +30,8 @@ function login() {
 
 function sendMessage() {
   const text = document.getElementById('messageInput').value;
-  fetch('/api/messages', {
+  // Send a new chat message to the API
+  fetch(`${API_BASE_URL}/api/messages`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ user: currentUser.username, text })
@@ -31,7 +40,8 @@ function sendMessage() {
 }
 
 function loadMessages() {
-  fetch('/api/messages')
+  // Retrieve the latest chat messages from the API
+  fetch(`${API_BASE_URL}/api/messages`)
     .then(r => r.json())
     .then(msgs => {
       const list = document.getElementById('messageList');


### PR DESCRIPTION
## Summary
- configure `API_BASE_URL` in frontend
- use `API_BASE_URL` when requesting API routes
- document how to change API base URL

## Testing
- `npm run build` in `backend`
- `npm test` *(fails: Missing script)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68778606964483289ea29b701c8af0c0