### PR TITLE
Update docs to avoid static server 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Dash is an example enterprise web platform demonstrating several features:
    ```
 2. Serve the frontend using any static file server:
    ```bash
+   # If you run this from the repository root use the path to the
+   # `frontend` folder. When inside the `frontend` directory, simply run
+   # `npx serve` or `npx serve .` so the correct directory is served.
    npx serve frontend
    ```
    The JavaScript code assumes the API is available on `http://localhost:3000`.


### PR DESCRIPTION
## Summary
- clarify that `npx serve frontend` should be run from the repo root
- mention alternative command when already inside `frontend`

## Testing
- `npm run build` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_687806091ffc83289a0b1f7aff6956bf