### PR TITLE
Add user signup functionality

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -16,4 +16,28 @@ router.post('/login', (req, res) => {
   res.json({ id: user.id, username: user.username, role: user.role });
 });
 
+// Sign up endpoint to register a new user in-memory
+router.post('/signup', (req, res) => {
+  const { username, password } = req.body;
+
+  // Reject sign up if username already exists
+  if (users.some(u => u.username === username)) {
+    return res.status(400).json({ message: 'Username already taken' });
+  }
+
+  // Create a new user object with the next available id
+  const newUser: User = {
+    id: users.length + 1,
+    username,
+    password,
+    role: 'user'
+  };
+
+  // Add to the in-memory list (note: not persisted across restarts)
+  users.push(newUser);
+
+  // Return the created user info
+  res.json({ id: newUser.id, username: newUser.username, role: newUser.role });
+});
+
 export default router;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,14 @@
     <p id="loginStatus"></p>
   </div>
 
+  <div id="signup">
+    <h2>Sign Up</h2>
+    <input id="signupUsername" placeholder="username" />
+    <input id="signupPassword" placeholder="password" type="password" />
+    <button onclick="signup()">Sign Up</button>
+    <p id="signupStatus"></p>
+  </div>
+
   <section id="messages" style="display:none;">
     <h2>Instant Messages</h2>
     <div id="messageList"></div>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -28,6 +28,25 @@ function login() {
     });
 }
 
+// Register a new user via the signup form
+function signup() {
+  const username = document.getElementById('signupUsername').value;
+  const password = document.getElementById('signupPassword').value;
+
+  fetch(`${API_BASE_URL}/api/auth/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  })
+    .then(r => r.ok ? r.json() : r.json().then(d => Promise.reject(d.message || 'Signup failed')))
+    .then(u => {
+      document.getElementById('signupStatus').textContent = `Account ${u.username} created`;
+    })
+    .catch(err => {
+      document.getElementById('signupStatus').textContent = err;
+    });
+}
+
 function sendMessage() {
   const text = document.getElementById('messageInput').value;
   // Send a new chat message to the API


### PR DESCRIPTION
## Summary
- add `/signup` route on backend and update TypeScript build
- provide signup section in the frontend UI
- allow registering a new user via a signup() function

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687810c439288328abc7a12090b21de7