### PR TITLE
Serve frontend via backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,16 @@ Dash is an example enterprise web platform demonstrating several features:
 
 ### Running locally
 
-1. Install dependencies for the backend:
+1. Install dependencies and start the server (which now also serves the
+   frontend):
    ```bash
    cd backend
    npm install
    npm run build
    npm start
    ```
-2. Serve the frontend using any static file server:
-   ```bash
-   # If you run this from the repository root use the path to the
-   # `frontend` folder. When inside the `frontend` directory, simply run
-   # `npx serve` or `npx serve .` so the correct directory is served.
-   npx serve frontend
-   ```
+   Browse to `http://localhost:3000` and the web interface should load
+   without a separate static file server.
    The JavaScript code assumes the API is available on `http://localhost:3000`.
    If your backend runs elsewhere, update `API_BASE_URL` in
    `frontend/js/app.js` accordingly so requests reach the correct server.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 import cors from 'cors';
+import path from 'path';
 
 import authRoutes from './routes/auth';
 import messageRoutes from './routes/messages';
@@ -26,9 +27,21 @@ app.use('/api/programs', programRoutes);
 app.use('/api/timesheets', timesheetRoutes);
 app.use('/api/leaves', leaveRoutes);
 
-// Health check endpoint
-app.get('/', (_, res) => {
+// Serve static frontend files. The path is resolved relative to the compiled
+// JavaScript location so it works when running from the 'dist' directory.
+const frontendDir = path.resolve(__dirname, '..', '..', 'frontend');
+app.use(express.static(frontendDir));
+
+// Health check endpoint for the API
+app.get('/api', (_, res) => {
   res.send('Dash API is running');
+});
+
+// All remaining requests should be served the frontend's index.html so that
+// direct navigation to routes works without returning a 404.
+// Use a generic handler so all unmatched routes return the same HTML file.
+app.use((_, res) => {
+  res.sendFile(path.join(frontendDir, 'index.html'));
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- serve static files from backend/dist
- update health check endpoint
- point unmatched routes to `index.html`
- update docs for unified server setup

## Testing
- `npm install`
- `npm run build`
- `npm start` (fails if start fails)

------
https://chatgpt.com/codex/tasks/task_e_687a6f1e543483289f64edf0643098ad