### PR TITLE
Enhance chat with channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Dash is an example enterprise web platform demonstrating several features:
 
-- Instant messaging
+- Instant messaging with multiple channels and message editing
 - Basic CRM and project/program management
 - Timesheets and leave requests
 - Role-based authentication with admin, team admin and user levels

--- a/backend/src/models/channel.ts
+++ b/backend/src/models/channel.ts
@@ -1,0 +1,16 @@
+import { Schema, model, Document } from 'mongoose';
+
+/**
+ * Chat channel that messages can belong to.
+ */
+export interface IChannel extends Document {
+  /** Human readable name */
+  name: string;
+}
+
+const ChannelSchema = new Schema<IChannel>({
+  // Channel names must be unique for easy lookup
+  name: { type: String, required: true, unique: true }
+});
+
+export const Channel = model<IChannel>('Channel', ChannelSchema);

--- a/backend/src/models/message.ts
+++ b/backend/src/models/message.ts
@@ -1,16 +1,27 @@
 import { Schema, model, Document } from 'mongoose';
 
 /**
+ * Optional association to the channel this message belongs to.
+ */
+import { IChannel } from './channel';
+
+/**
  * Chat message sent by a user.
  */
 export interface IMessage extends Document {
+  /** Username of the sender */
   user: string;
+  /** Message contents */
   text: string;
+  /** Channel association */
+  channel: Schema.Types.ObjectId | IChannel;
 }
 
 const MessageSchema = new Schema<IMessage>({
   user: { type: String, required: true },
-  text: { type: String, required: true }
+  text: { type: String, required: true },
+  // Reference to the channel so queries can filter by room
+  channel: { type: Schema.Types.ObjectId, ref: 'Channel', required: true }
 });
 
 export const Message = model<IMessage>('Message', MessageSchema);

--- a/backend/src/routes/channels.ts
+++ b/backend/src/routes/channels.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import { authMiddleware, requireRole } from '../middleware/authMiddleware';
+import { Channel } from '../models/channel';
+
+const router = Router();
+
+// Require authentication on all channel routes
+router.use(authMiddleware);
+
+// Return all channels
+router.get('/', async (_, res) => {
+  const list = await Channel.find().exec();
+  res.json(list);
+});
+
+// Create a new channel
+router.post('/', requireRole(['user', 'teamAdmin', 'admin']), async (req, res) => {
+  const { name } = req.body;
+  const channel = new Channel({ name });
+  await channel.save();
+  res.status(201).json(channel);
+});
+
+export default router;

--- a/backend/src/routes/messages.ts
+++ b/backend/src/routes/messages.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { authMiddleware, requireRole } from '../middleware/authMiddleware';
+import { authMiddleware, requireRole, AuthRequest } from '../middleware/authMiddleware';
 import { Message } from '../models/message';
 
 const router = Router();
@@ -8,17 +8,62 @@ const router = Router();
 router.use(authMiddleware);
 
 // Retrieve all chat messages from the database
+// Return messages for a specific channel
+router.get('/channel/:id', async (req, res) => {
+  const msgs = await Message.find({ channel: req.params.id }).exec();
+  res.json(msgs);
+});
+
+// Retrieve all chat messages (across all channels)
 router.get('/', async (_, res) => {
   const msgs = await Message.find().exec();
   res.json(msgs);
 });
 
 // Store a new chat message
-router.post('/', requireRole(['user', 'teamAdmin', 'admin']), async (req, res) => {
-  const { user, text } = req.body;
-  const msg = new Message({ user, text });
+router.post('/', requireRole(['user', 'teamAdmin', 'admin']), async (req: AuthRequest, res) => {
+  const { text, channel } = req.body;
+  // The user field is taken from the authenticated request
+  const user = req.user!.username;
+  const msg = new Message({ user, text, channel });
   await msg.save();
   res.status(201).json(msg);
+});
+
+// Edit an existing message's text
+router.put('/:id', requireRole(['user', 'teamAdmin', 'admin']), async (req: AuthRequest, res) => {
+  const id = req.params.id;
+  const msg = await Message.findById(id);
+
+  if (!msg) {
+    return res.status(404).json({ message: 'Message not found' });
+  }
+
+  // Only the original author or admins may edit
+  if (msg.user !== req.user!.username && req.user!.role === 'user') {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+
+  msg.text = req.body.text;
+  await msg.save();
+  res.json(msg);
+});
+
+// Delete a message
+router.delete('/:id', requireRole(['user', 'teamAdmin', 'admin']), async (req: AuthRequest, res) => {
+  const id = req.params.id;
+  const msg = await Message.findById(id);
+
+  if (!msg) {
+    return res.status(404).json({ message: 'Message not found' });
+  }
+
+  if (msg.user !== req.user!.username && req.user!.role === 'user') {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+
+  await msg.deleteOne();
+  res.json({ message: 'Deleted' });
 });
 
 export default router;

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -27,6 +27,8 @@
     <!-- Chat messages area reused from the original example -->
     <section id="messages">
       <h2>Instant Messages</h2>
+      <label for="channelSelect">Channel:</label>
+      <select id="channelSelect" onchange="changeChannel()"></select>
       <div id="messageList"></div>
       <input id="messageInput" placeholder="Message" />
       <button onclick="sendMessage()">Send</button>


### PR DESCRIPTION
## Summary
- introduce `Channel` model and routes
- add channel to `Message` model
- implement editing/deleting messages
- allow joining channels via Socket.IO
- load channels and switch between them on the dashboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c1735193c8328a6ca675a1e482c8e