### PR TITLE
Add gravatar-based avatars

### DIFF
--- a/backend/src/models/directMessage.ts
+++ b/backend/src/models/directMessage.ts
@@ -1,0 +1,25 @@
+import { Schema, model, Document } from 'mongoose';
+
+/**
+ * Direct message exchanged between two users.
+ */
+export interface IDirectMessage extends Document {
+  /** Username of the sender */
+  from: string;
+  /** Username of the recipient */
+  to: string;
+  /** Message contents */
+  text: string;
+  /** Time the message was created */
+  createdAt: Date;
+}
+
+const DirectMessageSchema = new Schema<IDirectMessage>({
+  from: { type: String, required: true },
+  to: { type: String, required: true },
+  text: { type: String, required: true },
+  // Automatically store creation timestamp
+  createdAt: { type: Date, default: Date.now }
+});
+
+export const DirectMessage = model<IDirectMessage>('DirectMessage', DirectMessageSchema);

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,0 +1,51 @@
+import { Router } from 'express';
+import { authMiddleware, AuthRequest } from '../middleware/authMiddleware';
+import { User } from '../models/user';
+import { DirectMessage } from '../models/directMessage';
+
+const router = Router();
+
+// Ensure all routes in this file require authentication
+router.use(authMiddleware);
+
+/**
+ * Get a list of all registered users. Only exposes the username.
+ */
+router.get('/', async (_req, res) => {
+  const users = await User.find().select('username').exec();
+  res.json(users);
+});
+
+/**
+ * Retrieve the conversation between the logged in user and another user.
+ */
+router.get('/conversation/:user', async (req: AuthRequest, res) => {
+  const other = req.params.user;
+  const current = req.user!.username;
+
+  // Find messages where the current user is either the sender or recipient
+  const msgs = await DirectMessage.find({
+    $or: [
+      { from: current, to: other },
+      { from: other, to: current }
+    ]
+  }).sort({ createdAt: 1 }).exec();
+
+  res.json(msgs);
+});
+
+/**
+ * Send a direct message to another user.
+ */
+router.post('/conversation/:user', async (req: AuthRequest, res) => {
+  const other = req.params.user;
+  const current = req.user!.username;
+  const { text } = req.body;
+
+  const msg = new DirectMessage({ from: current, to: other, text });
+  await msg.save();
+
+  res.status(201).json(msg);
+});
+
+export default router;

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -73,3 +73,23 @@ button {
   padding: 0.5rem 1rem;
   margin-top: 0.5rem;
 }
+
+/* Styles for direct messages */
+.message {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.message .avatar {
+  width: 32px;
+  height: 32px;
+  margin-right: 0.5rem;
+  border-radius: 50%;
+}
+
+.message .time {
+  color: #777;
+  margin-left: auto;
+  font-size: 0.8rem;
+}

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -21,6 +21,8 @@
       <li><a href="#" onclick="alert('CRM coming soon')">CRM</a></li>
       <li><a href="#" onclick="alert('Projects coming soon')">Projects</a></li>
     </ul>
+    <p><strong>Users</strong></p>
+    <ul id="userList"></ul>
   </aside>
 
   <main class="content">

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -32,9 +32,11 @@ function loadSocketIo() {
   return socketIoReady;
 }
 
-let currentUser = null; // stores logged in user info
+// Logged in user information including avatar URL
+let currentUser = null;
 let socket = null;      // active Socket.IO connection
 let currentChannel = null; // id of the selected channel
+let selectedUser = null; // username of direct message recipient
 
 function login() {
   const username = document.getElementById('username').value;
@@ -52,6 +54,8 @@ function login() {
       // Persist auth details so other pages can verify login state
       localStorage.setItem('token', u.token);
       localStorage.setItem('username', u.username);
+      // Store calculated gravatar URL so it can be reused on the dashboard
+      localStorage.setItem('avatarUrl', getGravatarUrl(u.username));
 
       // Redirect straight to the dashboard where the websocket
       // connection will be established.
@@ -88,16 +92,25 @@ function signup() {
 function sendMessage() {
   const text = document.getElementById('messageInput').value;
 
-  if (!socket || !text || !currentChannel) {
+  if (!socket || !text) {
     return;
   }
 
-  // Emit the message and include the channel for routing on the server
-  socket.emit('messages', {
-    user: currentUser.username,
-    text,
-    channel: currentChannel
-  });
+  if (selectedUser) {
+    // Direct message to another user
+    socket.emit('directMessage', {
+      from: currentUser.username,
+      to: selectedUser,
+      text
+    });
+  } else if (currentChannel) {
+    // Channel message
+    socket.emit('messages', {
+      user: currentUser.username,
+      text,
+      channel: currentChannel
+    });
+  }
 
   // Clear the input for convenience
   document.getElementById('messageInput').value = '';
@@ -140,17 +153,22 @@ function changeChannel() {
 }
 
 function loadMessages() {
-  if (!currentChannel) {
-    return;
+  const list = document.getElementById('messageList');
+  list.innerHTML = '';
+
+  if (selectedUser) {
+    // Load direct messages with the selected user
+    fetch(`${API_BASE_URL}/api/users/conversation/${selectedUser}`, {
+      headers: { Authorization: `Bearer ${currentUser.token}` }
+    })
+      .then(r => r.json())
+      .then(msgs => msgs.forEach(appendDirectMessage));
+  } else if (currentChannel) {
+    // Retrieve the latest chat messages for the active channel
+    fetch(`${API_BASE_URL}/api/messages/channel/${currentChannel}`)
+      .then(r => r.json())
+      .then(msgs => msgs.forEach(appendMessage));
   }
-  // Retrieve the latest chat messages for the active channel
-  fetch(`${API_BASE_URL}/api/messages/channel/${currentChannel}`)
-    .then(r => r.json())
-    .then(msgs => {
-      const list = document.getElementById('messageList');
-      list.innerHTML = '';
-      msgs.forEach(appendMessage);
-    });
 }
 
 // Helper to add a single message element to the chat log
@@ -159,6 +177,46 @@ function appendMessage(m) {
   const div = document.createElement('div');
   div.innerHTML = `<strong>${m.user}:</strong> ${m.text}`;
   list.appendChild(div);
+}
+
+// Render a direct message including timestamp and avatars
+function appendDirectMessage(m) {
+  const list = document.getElementById('messageList');
+  const div = document.createElement('div');
+  const time = new Date(m.createdAt).toLocaleTimeString();
+  div.className = 'message';
+  div.innerHTML = `
+    <img class="avatar" src="${getGravatarUrl(m.from)}" alt="avatar">
+    <span class="user">${m.from}</span>
+    <span class="time">${time}</span>
+    <span class="text">${m.text}</span>`;
+  list.appendChild(div);
+}
+
+// Fetch list of all users for the sidebar
+function loadUsers() {
+  fetch(`${API_BASE_URL}/api/users`, {
+    headers: { Authorization: `Bearer ${currentUser.token}` }
+  })
+    .then(r => r.json())
+    .then(users => {
+      const list = document.getElementById('userList');
+      list.innerHTML = '';
+      users.forEach(u => {
+        if (u.username === currentUser.username) return; // skip self
+        const li = document.createElement('li');
+        li.textContent = u.username;
+        li.onclick = () => selectUser(u.username);
+        list.appendChild(li);
+      });
+    });
+}
+
+// Select a user to view direct conversation
+function selectUser(name) {
+  selectedUser = name;
+  currentChannel = null; // hide channel context
+  loadMessages();
 }
 
 // Verify the user is logged in before showing the dashboard
@@ -171,13 +229,22 @@ function checkAuth() {
     return;
   }
 
-  currentUser = { username, token };
+  const avatarUrl = localStorage.getItem('avatarUrl') || getGravatarUrl(username);
+  currentUser = { username, token, avatarUrl };
 
   // After setting currentUser, connect to Socket.IO and load channels/messages
   loadSocketIo().then(() => {
     socket = io(API_BASE_URL);
+    socket.emit('register', currentUser.username);
     socket.on('messages', msg => appendMessage(msg));
+    socket.on('directMessage', dm => {
+      // Only show incoming messages if conversation is open
+      if (selectedUser === dm.from || selectedUser === dm.to) {
+        appendDirectMessage(dm);
+      }
+    });
     loadChannels();
+    loadUsers();
   });
 }
 
@@ -185,8 +252,160 @@ function checkAuth() {
 function logout() {
   localStorage.removeItem('token');
   localStorage.removeItem('username');
+  localStorage.removeItem('avatarUrl');
   if (socket) {
     socket.disconnect();
   }
   window.location.href = 'login.html';
+}
+
+/**
+ * Return the Gravatar URL for the given identifier. The identifier is
+ * typically an email address but here we simply use the username so users
+ * don't need to upload avatars. The username is lowercased and hashed
+ * with MD5 per the Gravatar specification.
+ */
+function getGravatarUrl(id) {
+  const hash = md5(id.trim().toLowerCase());
+  return `https://www.gravatar.com/avatar/${hash}?d=identicon`;
+}
+
+/**
+ * JavaScript implementation of the MD5 hash function. Based on the reference
+ * implementation at https://www.myersdaily.org/joseph/javascript/md5-text.html
+ * and adapted for clarity. Returns a hex string.
+ */
+function md5(str) {
+  function cmn(q, a, b, x, s, t) {
+    a = add32(add32(a, q), add32(x, t));
+    return add32((a << s) | (a >>> (32 - s)), b);
+  }
+  function ff(a, b, c, d, x, s, t) {
+    return cmn((b & c) | (~b & d), a, b, x, s, t);
+  }
+  function gg(a, b, c, d, x, s, t) {
+    return cmn((b & d) | (c & ~d), a, b, x, s, t);
+  }
+  function hh(a, b, c, d, x, s, t) {
+    return cmn(b ^ c ^ d, a, b, x, s, t);
+  }
+  function ii(a, b, c, d, x, s, t) {
+    return cmn(c ^ (b | ~d), a, b, x, s, t);
+  }
+
+  function md5cycle(x, k) {
+    let [a, b, c, d] = x;
+
+    a = ff(a, b, c, d, k[0], 7, -680876936);
+    d = ff(d, a, b, c, k[1], 12, -389564586);
+    c = ff(c, d, a, b, k[2], 17, 606105819);
+    b = ff(b, c, d, a, k[3], 22, -1044525330);
+    a = ff(a, b, c, d, k[4], 7, -176418897);
+    d = ff(d, a, b, c, k[5], 12, 1200080426);
+    c = ff(c, d, a, b, k[6], 17, -1473231341);
+    b = ff(b, c, d, a, k[7], 22, -45705983);
+    a = ff(a, b, c, d, k[8], 7, 1770035416);
+    d = ff(d, a, b, c, k[9], 12, -1958414417);
+    c = ff(c, d, a, b, k[10], 17, -42063);
+    b = ff(b, c, d, a, k[11], 22, -1990404162);
+    a = ff(a, b, c, d, k[12], 7, 1804603682);
+    d = ff(d, a, b, c, k[13], 12, -40341101);
+    c = ff(c, d, a, b, k[14], 17, -1502002290);
+    b = ff(b, c, d, a, k[15], 22, 1236535329);
+
+    a = gg(a, b, c, d, k[1], 5, -165796510);
+    d = gg(d, a, b, c, k[6], 9, -1069501632);
+    c = gg(c, d, a, b, k[11], 14, 643717713);
+    b = gg(b, c, d, a, k[0], 20, -373897302);
+    a = gg(a, b, c, d, k[5], 5, -701558691);
+    d = gg(d, a, b, c, k[10], 9, 38016083);
+    c = gg(c, d, a, b, k[15], 14, -660478335);
+    b = gg(b, c, d, a, k[4], 20, -405537848);
+    a = gg(a, b, c, d, k[9], 5, 568446438);
+    d = gg(d, a, b, c, k[14], 9, -1019803690);
+    c = gg(c, d, a, b, k[3], 14, -187363961);
+    b = gg(b, c, d, a, k[8], 20, 1163531501);
+    a = gg(a, b, c, d, k[13], 5, -1444681467);
+    d = gg(d, a, b, c, k[2], 9, -51403784);
+    c = gg(c, d, a, b, k[7], 14, 1735328473);
+    b = gg(b, c, d, a, k[12], 20, -1926607734);
+
+    a = hh(a, b, c, d, k[5], 4, -378558);
+    d = hh(d, a, b, c, k[8], 11, -2022574463);
+    c = hh(c, d, a, b, k[11], 16, 1839030562);
+    b = hh(b, c, d, a, k[14], 23, -35309556);
+    a = hh(a, b, c, d, k[1], 4, -1530992060);
+    d = hh(d, a, b, c, k[4], 11, 1272893353);
+    c = hh(c, d, a, b, k[7], 16, -155497632);
+    b = hh(b, c, d, a, k[10], 23, -1094730640);
+    a = hh(a, b, c, d, k[13], 4, 681279174);
+    d = hh(d, a, b, c, k[0], 11, -358537222);
+    c = hh(c, d, a, b, k[3], 16, -722521979);
+    b = hh(b, c, d, a, k[6], 23, 76029189);
+    a = hh(a, b, c, d, k[9], 4, -640364487);
+    d = hh(d, a, b, c, k[12], 11, -421815835);
+    c = hh(c, d, a, b, k[15], 16, 530742520);
+    b = hh(b, c, d, a, k[2], 23, -995338651);
+
+    a = ii(a, b, c, d, k[0], 6, -198630844);
+    d = ii(d, a, b, c, k[7], 10, 1126891415);
+    c = ii(c, d, a, b, k[14], 15, -1416354905);
+    b = ii(b, c, d, a, k[5], 21, -57434055);
+    a = ii(a, b, c, d, k[12], 6, 1700485571);
+    d = ii(d, a, b, c, k[3], 10, -1894986606);
+    c = ii(c, d, a, b, k[10], 15, -1051523);
+    b = ii(b, c, d, a, k[1], 21, -2054922799);
+    a = ii(a, b, c, d, k[8], 6, 1873313359);
+    d = ii(d, a, b, c, k[15], 10, -30611744);
+    c = ii(c, d, a, b, k[6], 15, -1560198380);
+    b = ii(b, c, d, a, k[13], 21, 1309151649);
+    a = ii(a, b, c, d, k[4], 6, -145523070);
+    d = ii(d, a, b, c, k[11], 10, -1120210379);
+    c = ii(c, d, a, b, k[2], 15, 718787259);
+    b = ii(b, c, d, a, k[9], 21, -343485551);
+
+    x[0] = add32(a, x[0]);
+    x[1] = add32(b, x[1]);
+    x[2] = add32(c, x[2]);
+    x[3] = add32(d, x[3]);
+  }
+
+  function md51(s) {
+    const txt = unescape(encodeURI(s));
+    const n = txt.length;
+    const state = [1732584193, -271733879, -1732584194, 271733878];
+    const arr = [];
+    for (let i = 0; i < n; i++) {
+      arr[i >> 2] |= txt.charCodeAt(i) << ((i % 4) << 3);
+    }
+    arr[n >> 2] |= 0x80 << ((n % 4) << 3);
+    arr[(((n + 8) >> 6) + 1) * 16 - 2] = n * 8;
+
+    for (let i = 0; i < arr.length; i += 16) {
+      md5cycle(state, arr.slice(i, i + 16));
+    }
+
+    return state;
+  }
+
+  function rhex(n) {
+    let s = '', j = 0;
+    for (; j < 4; j++) {
+      s += ((n >> (j * 8 + 4)) & 0x0f).toString(16) + ((n >> (j * 8)) & 0x0f).toString(16);
+    }
+    return s;
+  }
+
+  function hex(x) {
+    for (let i = 0; i < x.length; i++) {
+      x[i] = rhex(x[i]);
+    }
+    return x.join('');
+  }
+
+  function add32(a, b) {
+    return (a + b) & 0xffffffff;
+  }
+
+  return hex(md51(str));
 }


### PR DESCRIPTION
## Summary
- remove static avatar image
- store gravatar URL during login
- display gravatar in direct messages
- include helper to compute gravatar hash

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ca2bcef48832885f75756acfed9a0