### PR TITLE
Add demo user seeding

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ import userRoutes from './routes/users';
 import { connectDB } from './db';
 import { Message } from './models/message';
 import { DirectMessage } from './models/directMessage';
+import { seedUsers } from './seedUsers';
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -107,7 +108,10 @@ app.use((_, res) => {
 
 // Connect to MongoDB then start the HTTP server
 connectDB()
-  .then(() => {
+  .then(async () => {
+    // Populate demo accounts before accepting connections
+    await seedUsers();
+
     // Start the combined HTTP/WebSocket server once the DB is ready
     server.listen(PORT, () => {
       console.log(`Server listening on port ${PORT}`);

--- a/backend/src/seedUsers.ts
+++ b/backend/src/seedUsers.ts
@@ -1,0 +1,19 @@
+import bcrypt from 'bcrypt';
+import { User } from './models/user';
+
+/**
+ * Ensure a set of demo users exist in the database. Each user has the
+ * same value for username and password so they are easy to log in with
+ * during demos.
+ */
+export async function seedUsers(): Promise<void> {
+  const names = ['jack', 'jill', 'alice', 'bob', 'eve'];
+  for (const username of names) {
+    // Only create the account if it doesn't already exist
+    if (!(await User.exists({ username }))) {
+      const hashed = await bcrypt.hash(username, 10);
+      const user = new User({ username, password: hashed, role: 'user' });
+      await user.save();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- seed initial users for demo purposes
- populate demo accounts before starting server

## Testing
- `npm install` in `backend`
- `npm run build` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_687ca7d7fe1c8328844137aedf143a31