### PR TITLE
Implement two-sidebar dashboard layout

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -31,33 +31,65 @@ header nav a {
   margin-bottom: 1rem;
 }
 
-/* Dashboard layout with sidebar and main content */
-.sidebar {
-  position: fixed;
-  top: 60px;
-  left: 0;
+/* Layout for the dashboard with two sidebars similar to Slack/Teams */
+.main-layout {
+  display: flex;
+  height: calc(100vh - 60px); /* subtract header height */
+}
+
+/* Narrow tool selector on the far left */
+.tool-sidebar {
+  width: 60px;
+  background: #333;
+  color: #fff;
+  padding-top: 1rem;
+  box-sizing: border-box;
+}
+
+.tool-sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  text-align: center;
+}
+
+.tool-sidebar li {
+  padding: 0.5rem 0;
+  cursor: pointer;
+}
+
+.tool-sidebar li.active {
+  background: #555;
+}
+
+/* Contextual sidebar shown for the selected tool */
+.context-sidebar {
   width: 200px;
-  height: calc(100vh - 60px);
   background: #f4f4f4;
   padding: 1rem;
   box-sizing: border-box;
 }
 
 .content {
-  margin-left: 200px;
+  flex: 1;
   padding: 1rem;
   box-sizing: border-box;
+  overflow-y: auto;
 }
 
 /* Responsive adjustments */
 @media (max-width: 768px) {
-  .sidebar {
-    position: static;
-    width: 100%;
+  .main-layout {
+    flex-direction: column;
     height: auto;
   }
-  .content {
-    margin-left: 0;
+  .tool-sidebar {
+    width: 100%;
+    display: flex;
+    justify-content: space-around;
+  }
+  .context-sidebar {
+    width: 100%;
   }
 }
 
@@ -92,4 +124,9 @@ button {
   color: #777;
   margin-left: auto;
   font-size: 0.8rem;
+}
+
+/* Utility class to toggle visibility */
+.hidden {
+  display: none;
 }

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -14,28 +14,50 @@
     </nav>
   </header>
 
-  <aside class="sidebar">
-    <p><strong>Navigation</strong></p>
-    <ul>
-      <li><a href="#messages">Messages</a></li>
-      <li><a href="#" onclick="alert('CRM coming soon')">CRM</a></li>
-      <li><a href="#" onclick="alert('Projects coming soon')">Projects</a></li>
-    </ul>
-    <p><strong>Users</strong></p>
-    <ul id="userList"></ul>
-  </aside>
+  <!-- Main layout with two sidebars -->
+  <div class="main-layout">
+    <!-- Left sidebar for selecting the active business tool -->
+    <nav class="tool-sidebar">
+      <ul>
+        <li id="tool-messages" class="active" onclick="selectTool('messages')">💬</li>
+        <li id="tool-crm" onclick="selectTool('crm')">CRM</li>
+        <li id="tool-timesheets" onclick="selectTool('timesheets')">TS</li>
+        <li id="tool-recruit" onclick="selectTool('recruit')">HR</li>
+      </ul>
+    </nav>
 
-  <main class="content">
-    <!-- Chat messages area reused from the original example -->
-    <section id="messages">
-      <h2>Instant Messages</h2>
-      <label for="channelSelect">Channel:</label>
-      <select id="channelSelect" onchange="changeChannel()"></select>
-      <div id="messageList"></div>
-      <input id="messageInput" placeholder="Message" />
-      <button onclick="sendMessage()">Send</button>
-    </section>
-  </main>
+    <!-- Contextual sidebar which changes based on the selected tool -->
+    <aside class="context-sidebar" id="contextSidebar">
+      <p><strong>Users</strong></p>
+      <ul id="userList"></ul>
+    </aside>
+
+    <main class="content">
+      <!-- Messaging section -->
+      <section id="messages">
+        <h2>Instant Messages</h2>
+        <label for="channelSelect">Channel:</label>
+        <select id="channelSelect" onchange="changeChannel()"></select>
+        <div id="messageList"></div>
+        <input id="messageInput" placeholder="Message" />
+        <button onclick="sendMessage()">Send</button>
+      </section>
+
+      <!-- Placeholder sections for future tools -->
+      <section id="crm" class="hidden">
+        <h2>CRM</h2>
+        <p>CRM functionality coming soon.</p>
+      </section>
+      <section id="timesheets" class="hidden">
+        <h2>Timesheets</h2>
+        <p>Timesheets functionality coming soon.</p>
+      </section>
+      <section id="recruit" class="hidden">
+        <h2>Recruitment</h2>
+        <p>Recruitment functionality coming soon.</p>
+      </section>
+    </main>
+  </div>
 
   <!-- Socket.IO will be loaded dynamically if needed -->
   <script src="js/app.js"></script>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -37,6 +37,39 @@ let currentUser = null;
 let socket = null;      // active Socket.IO connection
 let currentChannel = null; // id of the selected channel
 let selectedUser = null; // username of direct message recipient
+let activeTool = 'messages'; // currently selected tool
+
+// Switch between major tools (messaging, CRM, etc.) and update layout
+function selectTool(tool) {
+  activeTool = tool;
+
+  // Highlight the selected tool in the sidebar
+  document.querySelectorAll('.tool-sidebar li').forEach(li => li.classList.remove('active'));
+  const activeItem = document.getElementById('tool-' + tool);
+  if (activeItem) activeItem.classList.add('active');
+
+  // Show or hide the contextual sidebar
+  const context = document.getElementById('contextSidebar');
+  if (tool === 'messages') {
+    context.classList.remove('hidden');
+    // Refresh messaging context when switching back
+    loadUsers();
+    loadChannels();
+  } else {
+    context.classList.add('hidden');
+  }
+
+  // Display the relevant section in the main area
+  document.querySelectorAll('.content > section').forEach(sec => sec.classList.add('hidden'));
+  const activeSection = document.getElementById(tool);
+  if (activeSection) activeSection.classList.remove('hidden');
+
+  // Clear message view state when leaving messaging
+  if (tool !== 'messages') {
+    selectedUser = null;
+    currentChannel = null;
+  }
+}
 
 function login() {
   const username = document.getElementById('username').value;
@@ -243,8 +276,8 @@ function checkAuth() {
         appendDirectMessage(dm);
       }
     });
-    loadChannels();
-    loadUsers();
+    // Default to messaging view once authenticated
+    selectTool('messages');
   });
 }
 


### PR DESCRIPTION
## Summary
- redesign dashboard with left tool bar and contextual sidebar
- add responsive styles for new layout
- implement tool switching logic in app.js

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687cb7115e2c8328a2e1f04179c070a2