### PR TITLE
Fix DB_URI setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ The frontend can be hosted separately or served by any static web server.
 
 ## Database Setup
 
-The backend now requires access to a MongoDB instance. Configure the
-connection string using the `DB_URI` environment variable or by placing it in a
-`.env` file in `backend/`:
+The backend now requires access to a MongoDB instance. Copy the provided
+`.env.example` to `.env` inside `backend/` and update the `DB_URI` value if your
+database runs elsewhere. Alternatively you can export the variable in your
+shell:
 
 ```bash
 export DB_URI="mongodb://localhost:27017/dash"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for the Dash backend
+# Update DB_URI if your MongoDB instance runs elsewhere
+DB_URI=mongodb://localhost:27017/dash

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,7 +1,11 @@
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
+import path from 'path';
 
-dotenv.config();
+// Load environment variables from the backend root regardless of the current
+// working directory. This ensures the configuration is found when running the
+// compiled JavaScript from the `dist` directory.
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
 
 /**
  * Establishes a connection to the MongoDB database using the
@@ -9,6 +13,8 @@ dotenv.config();
  * so callers can await readiness before starting the server.
  */
 export async function connectDB(): Promise<typeof mongoose> {
+  // The connection string to MongoDB. If `DB_URI` is missing, a clear error is
+  // thrown so developers know they must configure the variable.
   const uri = process.env.DB_URI;
   if (!uri) {
     throw new Error('DB_URI environment variable not set');


### PR DESCRIPTION
## Summary
- document environment variable setup in README
- add sample `.env` file for DB_URI
- load `.env` reliably in `connectDB`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d490ea1c4832894abf294c2808fd4