### PR TITLE
Fix missing DB_URI configuration

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,3 @@
+# Example environment variables for the Dash backend
+# Update DB_URI if your MongoDB instance runs elsewhere
+DB_URI=mongodb://localhost:27017/dash


### PR DESCRIPTION
## Summary
- provide a sample `.env` that sets `DB_URI`

## Testing
- `npm install`
- `npm run build`
- `npm run db:init` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_687d4f0147d88328b0246945f8922aef