### PR TITLE
Improve chat with read receipts and unread badges

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -30,6 +30,8 @@ const server = http.createServer(app);
 const io = new Server(server, {
   cors: { origin: '*' }
 });
+// Make the Socket.IO instance accessible to route handlers via app.get('io')
+app.set('io', io);
 
 // Listen for new WebSocket connections
 io.on('connection', socket => {

--- a/backend/src/models/directMessage.ts
+++ b/backend/src/models/directMessage.ts
@@ -12,6 +12,8 @@ export interface IDirectMessage extends Document {
   text: string;
   /** Time the message was created */
   createdAt: Date;
+  /** Whether the recipient has viewed the message */
+  isRead: boolean;
 }
 
 const DirectMessageSchema = new Schema<IDirectMessage>({
@@ -19,7 +21,9 @@ const DirectMessageSchema = new Schema<IDirectMessage>({
   to: { type: String, required: true },
   text: { type: String, required: true },
   // Automatically store creation timestamp
-  createdAt: { type: Date, default: Date.now }
+  createdAt: { type: Date, default: Date.now },
+  // Track if the message has been read by the recipient
+  isRead: { type: Boolean, default: false }
 });
 
 export const DirectMessage = model<IDirectMessage>('DirectMessage', DirectMessageSchema);

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -144,3 +144,20 @@ button {
 .user-online .online-indicator {
   background: #0a0;
 }
+
+.message .read {
+  color: #0a0;
+  font-size: 0.8rem;
+  margin-left: 4px;
+}
+
+/* Badge showing the number of unread direct messages */
+.badge {
+  display: inline-block;
+  background: #e00;
+  color: #fff;
+  border-radius: 10px;
+  padding: 0 4px;
+  margin-left: 4px;
+  font-size: 0.75rem;
+}


### PR DESCRIPTION
## Summary
- track read status for direct messages
- expose unread message counts via new API route
- display unread badges and read receipts in the UI
- broadcast read receipts via WebSocket events

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d6abffdac8328acd7a800aa852184