### PR TITLE
Fix read receipt visibility

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -251,10 +251,10 @@ function appendDirectMessage(m) {
   // Convert message timestamp to a relative description like "5 minutes ago"
   const time = formatRelativeTime(m.createdAt);
   div.className = 'message';
-  // Only show read receipts on messages sent by the current user
-  const receipt = m.from === currentUser.username
-    ? `<span class="read">${m.isRead ? '✔✔' : '✔'}</span>`
-    : '';
+  // Display a read receipt for all messages. For outgoing messages this
+  // indicates whether the other user has viewed it. For incoming messages it
+  // simply reflects that the current user has read the message.
+  const receipt = `<span class="read">${m.isRead ? '✔✔' : '✔'}</span>`;
   div.innerHTML = `
     <img class="avatar" src="${getGravatarUrl(m.from)}" alt="avatar">
     <span class="user">${m.from}</span>


### PR DESCRIPTION
## Summary
- show read receipts for every direct message rather than only own messages

## Testing
- `npm run build` *(fails: cannot find module 'express' type declarations, TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687fa753b2688328906d41a095d365a2