### PR TITLE
Fix unread counters and read receipts

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -169,9 +169,14 @@ button {
 }
 
 .message .read {
-  color: #0a0;
+  color: #777; /* grey for delivered but not yet read */
   font-size: 0.8rem;
   margin-left: 4px;
+}
+
+/* When a message has been read show the ticks in green */
+.message .read.read-true {
+  color: #0a0;
 }
 
 /* Badge showing the number of unread direct messages */


### PR DESCRIPTION
## Summary
- mark direct messages as read via new `/api/users/read/:user` endpoint
- visually differentiate sent vs read ticks
- hide ticks on received messages
- sync unread counters when viewing a conversation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687faa9fa3f483288930460f4a741e96