### PR TITLE
Implement delivery receipts for direct messages

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -93,6 +93,21 @@ io.on('connection', socket => {
       console.error('Failed to process direct message', err);
     }
   });
+
+  // Recipient confirms a message reached their device
+  socket.on('messageDelivered', async ({ id }) => {
+    try {
+      const msg = await DirectMessage.findById(id);
+      if (msg && !msg.isDelivered) {
+        msg.isDelivered = true;
+        await msg.save();
+        // Inform the sender that delivery was successful
+        io.to(msg.from).emit('messagesDelivered', { ids: [id], to: msg.to });
+      }
+    } catch (err) {
+      console.error('Failed to process delivery receipt', err);
+    }
+  });
 });
 
 // Middleware configuration

--- a/backend/src/models/directMessage.ts
+++ b/backend/src/models/directMessage.ts
@@ -14,6 +14,8 @@ export interface IDirectMessage extends Document {
   createdAt: Date;
   /** Whether the recipient has viewed the message */
   isRead: boolean;
+  /** Whether the message reached the recipient's device */
+  isDelivered: boolean;
 }
 
 const DirectMessageSchema = new Schema<IDirectMessage>({
@@ -23,7 +25,9 @@ const DirectMessageSchema = new Schema<IDirectMessage>({
   // Automatically store creation timestamp
   createdAt: { type: Date, default: Date.now },
   // Track if the message has been read by the recipient
-  isRead: { type: Boolean, default: false }
+  isRead: { type: Boolean, default: false },
+  // Flag once the message is delivered to the recipient's device
+  isDelivered: { type: Boolean, default: false }
 });
 
 export const DirectMessage = model<IDirectMessage>('DirectMessage', DirectMessageSchema);


### PR DESCRIPTION
## Summary
- store delivery status on direct messages
- notify sender when a message is delivered via WebSocket
- mark messages delivered when a conversation is opened
- update frontend to send delivery acknowledgements and display single tick once delivered, double ticks when read

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687fb63b329c8328b34a576a47ddc894