### PR TITLE
Fix read receipt display

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -143,9 +143,15 @@ button {
   border-radius: 50%;
 }
 
+.message .text {
+  /* Allow the message body to consume remaining space so the
+     timestamp and read receipt align to the right */
+  flex: 1;
+}
+
 .message .time {
   color: #777;
-  margin-left: auto;
+  margin-left: 0.5rem; /* space after the message text */
   font-size: 0.8rem;
 }
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -262,11 +262,13 @@ function appendDirectMessage(m) {
     ? `<span class="read${m.isRead ? ' read-true' : ''}">${m.isRead ? '✔✔' : (m.isDelivered ? '✔' : '')}</span>`
     : '';
 
+  // Place the timestamp and read receipt at the end of the flex container so
+  // the layout resembles common chat apps.
   div.innerHTML = `
     <img class="avatar" src="${getGravatarUrl(m.from)}" alt="avatar">
     <span class="user">${m.from}</span>
-    <span class="time">${time}</span>
-    <span class="text">${m.text}</span>${receipt}`;
+    <span class="text">${m.text}</span>
+    <span class="time">${time}</span>${receipt}`;
   list.appendChild(div);
 }
 


### PR DESCRIPTION
## Summary
- arrange direct message markup so timestamp and receipts follow text
- let message text flex so receipts align correctly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687fb8b89db88328acfcb04ee12b8852