### PR TITLE
Fix read receipt display

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -143,9 +143,21 @@ button {
   border-radius: 50%;
 }
 
+.message .user {
+  font-weight: bold;       /* differentiate username from message text */
+  margin-right: 0.25rem;   /* spacing before the message body */
+}
+
+.message .text {
+  /* Allow the message body to consume remaining space so the
+     timestamp and read receipt align to the right */
+  flex: 1;
+  margin-left: 0.25rem;
+}
+
 .message .time {
   color: #777;
-  margin-left: auto;
+  margin-left: 0.5rem; /* space after the message text */
   font-size: 0.8rem;
 }
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -259,14 +259,16 @@ function appendDirectMessage(m) {
   // delivered.
   const outgoing = m.from === currentUser.username;
   const receipt = outgoing
-    ? `<span class="read${m.isRead ? ' read-true' : ''}">${m.isRead ? '✔✔' : (m.isDelivered ? '✔' : '')}</span>`
+    ? `<span class="read${m.isRead ? ' read-true' : ''}">${m.isRead ? '&#10003;&#10003;' : (m.isDelivered ? '&#10003;' : '')}</span>`
     : '';
 
+  // Place the timestamp and read receipt at the end of the flex container so
+  // the layout resembles common chat apps.
   div.innerHTML = `
     <img class="avatar" src="${getGravatarUrl(m.from)}" alt="avatar">
     <span class="user">${m.from}</span>
-    <span class="time">${time}</span>
-    <span class="text">${m.text}</span>${receipt}`;
+    <span class="text">${m.text}</span>
+    <span class="time">${time}</span>${receipt}`;
   list.appendChild(div);
 }
 
@@ -365,6 +367,9 @@ function selectUser(name) {
   currentChannel = null; // hide channel context
   clearUnread(name);
   loadMessages();
+  // Explicitly mark any previously unread messages as read now that
+  // the conversation is open to keep badge counts in sync.
+  markMessagesRead(name);
 }
 
 // Verify the user is logged in before showing the dashboard


### PR DESCRIPTION
## Summary
- style usernames and message text so they aren't jammed together
- show tick marks using HTML entities
- mark threads read when opening them to clear badges

## Testing
- `npm --prefix backend run build`


------
https://chatgpt.com/codex/tasks/task_e_687fb8b89db88328acfcb04ee12b8852