### PR TITLE
Fix message badges and layout

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -143,6 +143,12 @@ button {
   border-radius: 50%;
 }
 
+/* Style the sender name distinctly and leave space before the message text */
+.message .user {
+  font-weight: bold;
+  margin-right: 0.25rem;
+}
+
 .message .text {
   /* Allow the message body to consume remaining space so the
      timestamp and read receipt align to the right */

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -266,7 +266,7 @@ function appendDirectMessage(m) {
   // the layout resembles common chat apps.
   div.innerHTML = `
     <img class="avatar" src="${getGravatarUrl(m.from)}" alt="avatar">
-    <span class="user">${m.from}</span>
+    <span class="user">${m.from}:</span>
     <span class="text">${m.text}</span>
     <span class="time">${time}</span>${receipt}`;
   list.appendChild(div);
@@ -303,18 +303,18 @@ function loadUnreadCounts() {
     .then(r => r.json())
     .then(counts => {
       unreadCounts = counts;
-      Object.keys(counts).forEach(user => {
-        const li = document.querySelector(`#userList li[data-user="${user}"]`);
-        if (li) {
-          const badge = li.querySelector('.badge');
-          if (counts[user] > 0) {
-            badge.textContent = counts[user];
-            badge.classList.remove('hidden');
-            li.classList.add('unread');
-          } else {
-            badge.classList.add('hidden');
-            li.classList.remove('unread');
-          }
+      // Update every listed user so badges reset when a conversation is read
+      document.querySelectorAll('#userList li').forEach(li => {
+        const user = li.dataset.user;
+        const badge = li.querySelector('.badge');
+        const count = counts[user] || 0;
+        if (count > 0) {
+          badge.textContent = count;
+          badge.classList.remove('hidden');
+          li.classList.add('unread');
+        } else {
+          badge.classList.add('hidden');
+          li.classList.remove('unread');
         }
       });
     });


### PR DESCRIPTION
## Summary
- style usernames in chat messages
- show colon after sender name
- reset unread message badges when thread opened

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687fe0920b4c832883da924f22c89574