### PR TITLE
Fix unread counter when messages read

### DIFF
--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -56,6 +56,8 @@ router.get('/conversation/:user', async (req: AuthRequest, res) => {
   if (unread.modifiedCount > 0) {
     const io = req.app.get('io');
     io.to(other).emit('messagesRead', { from: current, count: unread.modifiedCount });
+    // Also notify the current user's other sessions so badges clear everywhere
+    io.to(current).emit('messagesRead', { from: other, count: unread.modifiedCount });
   }
 
   // Inform sender about newly delivered messages
@@ -120,6 +122,8 @@ router.post('/read/:user', async (req: AuthRequest, res) => {
   if (unread.modifiedCount > 0) {
     const io = req.app.get('io');
     io.to(other).emit('messagesRead', { from: current, count: unread.modifiedCount });
+    // Notify all of the reader's sessions as well
+    io.to(current).emit('messagesRead', { from: other, count: unread.modifiedCount });
   }
 
   res.json({ count: unread.modifiedCount });

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -406,8 +406,10 @@ function checkAuth() {
     });
     // Receive read receipt updates for sent messages
     socket.on('messagesRead', data => {
+      // Refresh badge counts in case another tab marked messages as read
+      loadUnreadCounts();
       if (selectedUser === data.from) {
-        // Reload counts and conversation so read indicators update
+        // If this conversation is visible update the chat log as well
         loadMessages();
       }
     });


### PR DESCRIPTION
## Summary
- broadcast `messagesRead` to all sessions of both users
- refresh unread badges whenever a `messagesRead` event is received

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68800c5de86083288d508d6cb4806958