### PR TITLE
Fix direct message delivery

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -87,8 +87,12 @@ io.on('connection', socket => {
     try {
       const dm = new DirectMessage({ from, to, text });
       await dm.save();
-      // Emit the message to both participants
-      io.to(from).to(to).emit('directMessage', dm);
+      // Emit the message to both participants. Using `io.to()` with an array
+      // sends to the union of rooms, but chaining `.to()` calls would emit only
+      // to sockets that are in **both** rooms. Send separately so each user
+      // receives the direct message regardless of whether they share any rooms.
+      io.to(from).emit('directMessage', dm);
+      io.to(to).emit('directMessage', dm);
     } catch (err) {
       console.error('Failed to process direct message', err);
     }


### PR DESCRIPTION
## Summary
- direct messages were not emitting to both participants
- send message to both users separately so delivered/read ticks update

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68800f0a2da48328926c13fedf33d6b5