### PR TITLE
Revamp message receipt handling

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -98,20 +98,6 @@ io.on('connection', socket => {
     }
   });
 
-  // Recipient confirms a message reached their device
-  socket.on('messageDelivered', async ({ id }) => {
-    try {
-      const msg = await DirectMessage.findById(id);
-      if (msg && !msg.isDelivered) {
-        msg.isDelivered = true;
-        await msg.save();
-        // Inform the sender that delivery was successful
-        io.to(msg.from).emit('messagesDelivered', { ids: [id], to: msg.to });
-      }
-    } catch (err) {
-      console.error('Failed to process delivery receipt', err);
-    }
-  });
 });
 
 // Middleware configuration

--- a/backend/src/models/directMessage.ts
+++ b/backend/src/models/directMessage.ts
@@ -12,10 +12,8 @@ export interface IDirectMessage extends Document {
   text: string;
   /** Time the message was created */
   createdAt: Date;
-  /** Whether the recipient has viewed the message */
-  isRead: boolean;
-  /** Whether the message reached the recipient's device */
-  isDelivered: boolean;
+  /** Whether the recipient has displayed the message */
+  isSeen: boolean;
 }
 
 const DirectMessageSchema = new Schema<IDirectMessage>({
@@ -24,10 +22,8 @@ const DirectMessageSchema = new Schema<IDirectMessage>({
   text: { type: String, required: true },
   // Automatically store creation timestamp
   createdAt: { type: Date, default: Date.now },
-  // Track if the message has been read by the recipient
-  isRead: { type: Boolean, default: false },
-  // Flag once the message is delivered to the recipient's device
-  isDelivered: { type: Boolean, default: false }
+  // Track whether the message has been shown on the recipient's screen
+  isSeen: { type: Boolean, default: false }
 });
 
 export const DirectMessage = model<IDirectMessage>('DirectMessage', DirectMessageSchema);


### PR DESCRIPTION
## Summary
- simplify receipt model to only track when a message is seen
- update APIs to mark messages seen and report unseen counts
- drop delivery receipts and rename events to `messagesSeen`
- adjust frontend to show grey tick on server acknowledgement and green double ticks when seen

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6880a1baa5188328b870012da48c3d00