### PR TITLE
Switch message ticks to text-based receipts

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -186,7 +186,7 @@ button {
   margin-left: 4px;
 }
 
-/* When a message has been read show the ticks in green */
+/* When a message has been read show the text in green */
 .message .read.read-true {
   color: #0a0;
 }

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -258,11 +258,14 @@ function appendDirectMessage(m) {
   const time = formatRelativeTime(m.createdAt);
   div.className = 'message';
   // Only show read receipts on messages sent by the current user. One grey
-  // tick means the server stored the message while two ticks turn green once
-  // the recipient has displayed it.
+  // indicator shows the message was delivered while a green indicator shows it
+  // has been read by the recipient.
   const outgoing = m.from === currentUser.username;
   const receipt = outgoing
-    ? `<span class="read${m.isSeen ? ' read-true' : ''}">${m.isSeen ? '✔✔' : '✔'}</span>`
+    // Display textual read receipts instead of tick icons so the interface is
+    // easier to debug. 'delivered' is shown until the recipient displays the
+    // message, after which it switches to 'read'.
+    ? `<span class="read${m.isSeen ? ' read-true' : ''}">${m.isSeen ? 'read' : 'delivered'}</span>`
     : '';
 
   // Place the timestamp and read receipt at the end of the flex container so


### PR DESCRIPTION
## Summary
- replace tick icons with the words `delivered` and `read`
- update CSS comment to reflect text-based receipts

## Testing
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68811c17725c8328b2e6feb2cd262456