### PR TITLE
Remove read receipt and badge UI

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -85,9 +85,6 @@ header nav a {
   align-items: center;
 }
 
-.context-sidebar li .badge {
-  margin-left: auto;
-}
 
 .context-sidebar li.unread {
   font-weight: bold;
@@ -180,24 +177,3 @@ button {
   background: #0a0;
 }
 
-.message .read {
-  color: #777; /* grey for delivered but not yet read */
-  font-size: 0.8rem;
-  margin-left: 4px;
-}
-
-/* When a message has been read show the text in green */
-.message .read.read-true {
-  color: #0a0;
-}
-
-/* Badge showing the number of unread direct messages */
-.badge {
-  display: inline-block;
-  background: #e00;
-  color: #fff;
-  border-radius: 10px;
-  padding: 0 4px;
-  margin-left: 4px;
-  font-size: 0.75rem;
-}


### PR DESCRIPTION
## Summary
- drop visual badges and read receipt indicators
- omit read receipt DOM elements when rendering messages
- update routes to avoid notifying message senders
- adjust client logic to only bold user names when unread messages exist

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688159004dcc832891454675402834ac