### PR TITLE
Implement teams with cross-team messaging

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,7 @@ import programRoutes from './routes/programs';
 import timesheetRoutes from './routes/timesheets';
 import leaveRoutes from './routes/leaves';
 import userRoutes from './routes/users';
+import teamRoutes from './routes/teams';
 import { connectDB } from './db';
 import { Message } from './models/message';
 import { DirectMessage } from './models/directMessage';
@@ -114,6 +115,7 @@ app.use('/api/programs', programRoutes);
 app.use('/api/timesheets', timesheetRoutes);
 app.use('/api/leaves', leaveRoutes);
 app.use('/api/users', userRoutes);
+app.use('/api/teams', teamRoutes);
 
 // Serve static frontend files. The path is resolved relative to the compiled
 // JavaScript location so it works when running from the 'dist' directory.

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -3,7 +3,7 @@ import jwt from 'jsonwebtoken';
 import { Role } from '../models/user';
 
 export interface AuthRequest extends Request {
-  user?: { id: string; username: string; role: Role };
+  user?: { id: string; username: string; role: Role; team?: string };
 }
 
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
@@ -25,8 +25,14 @@ export function authMiddleware(req: AuthRequest, res: Response, next: NextFuncti
       id: string;
       username: string;
       role: Role;
+      team?: string;
     };
-    req.user = { id: payload.id, username: payload.username, role: payload.role };
+    req.user = {
+      id: payload.id,
+      username: payload.username,
+      role: payload.role,
+      team: payload.team
+    };
     next();
   } catch (err) {
     return res.status(401).json({ message: 'Invalid token' });

--- a/backend/src/models/team.ts
+++ b/backend/src/models/team.ts
@@ -1,0 +1,25 @@
+import { Schema, model, Document } from 'mongoose';
+
+/**
+ * Team represents a company workspace. Members within a team
+ * can see each other and collaborate.
+ */
+export interface ITeam extends Document {
+  /** Display name of the team */
+  name: string;
+  /** Email domains automatically mapped to this team */
+  domains: string[];
+  /** Number of licensed seats available */
+  seats: number;
+}
+
+// Schema defining the team structure
+const TeamSchema = new Schema<ITeam>({
+  name: { type: String, required: true, unique: true },
+  // Domains let the sign up process auto-assign users based on their email
+  domains: [{ type: String }],
+  // Track how many named seats the team has purchased
+  seats: { type: Number, default: 5 }
+});
+
+export const Team = model<ITeam>('Team', TeamSchema);

--- a/backend/src/models/teamInvitation.ts
+++ b/backend/src/models/teamInvitation.ts
@@ -1,0 +1,19 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+/**
+ * Invitation token that allows a specific email to join a team.
+ */
+export interface ITeamInvitation extends Document {
+  email: string;
+  team: Types.ObjectId;
+  token: string;
+}
+
+// Stores invitations for onboarding new members
+const InvitationSchema = new Schema<ITeamInvitation>({
+  email: { type: String, required: true },
+  team: { type: Schema.Types.ObjectId, ref: 'Team', required: true },
+  token: { type: String, required: true, unique: true }
+});
+
+export const TeamInvitation = model<ITeamInvitation>('TeamInvitation', InvitationSchema);

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -1,4 +1,4 @@
-import { Schema, model, Document } from 'mongoose';
+import { Schema, model, Document, Types } from 'mongoose';
 
 export type Role = 'user' | 'teamAdmin' | 'admin';
 
@@ -9,12 +9,19 @@ export interface IUser extends Document {
   username: string;
   password: string;
   role: Role;
+  /** Reference to the team this user belongs to */
+  team?: Types.ObjectId;
+  /** Users from other teams allowed to message this user */
+  allowedContacts: Types.ObjectId[];
 }
 
 const UserSchema = new Schema<IUser>({
   username: { type: String, required: true, unique: true },
   password: { type: String, required: true },
-  role: { type: String, enum: ['user', 'teamAdmin', 'admin'], default: 'user' }
+  role: { type: String, enum: ['user', 'teamAdmin', 'admin'], default: 'user' },
+  team: { type: Schema.Types.ObjectId, ref: 'Team' },
+  // Cross-team contacts who may exchange direct messages
+  allowedContacts: [{ type: Schema.Types.ObjectId, ref: 'User' }]
 });
 
 export const User = model<IUser>('User', UserSchema);

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -2,6 +2,8 @@ import { Router } from 'express';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { User } from '../models/user';
+import { Team } from '../models/team';
+import { TeamInvitation } from '../models/teamInvitation';
 
 // Secret key used to sign JWT tokens. In production this should come from
 // an environment variable so each deployment can use a unique key.
@@ -27,7 +29,7 @@ router.post('/login', async (req, res) => {
 
   // Build a signed JWT containing the user id and role
   const token = jwt.sign(
-    { id: String(user._id), username: user.username, role: user.role },
+    { id: String(user._id), username: user.username, role: user.role, team: user.team ? String(user.team) : undefined },
     JWT_SECRET,
     { expiresIn: '1h' }
   );
@@ -42,7 +44,7 @@ router.post('/login', async (req, res) => {
 
 // Sign up endpoint to create a user document
 router.post('/signup', async (req, res) => {
-  const { username, password } = req.body;
+  const { username, password, teamId, token } = req.body;
 
   // Fail if the username already exists
   if (await User.exists({ username })) {
@@ -52,10 +54,50 @@ router.post('/signup', async (req, res) => {
   // Hash the password before storing in the database
   const hashed = await bcrypt.hash(password, 10);
 
-  const newUser = new User({ username, password: hashed, role: 'user' });
+  let team;
+  // Use invitation token if provided
+  if (token) {
+    const invite = await TeamInvitation.findOne({ token, email: username }).exec();
+    if (!invite) {
+      return res.status(400).json({ message: 'Invalid invitation token' });
+    }
+    team = await Team.findById(invite.team).exec();
+    if (!team) {
+      return res.status(400).json({ message: 'Invitation team missing' });
+    }
+    // consume invitation
+    await invite.deleteOne();
+  } else if (teamId) {
+    // Directly specify a team by id
+    team = await Team.findById(teamId).exec();
+  } else {
+    // Fallback to domain based matching
+    const parts = username.split('@');
+    if (parts.length === 2) {
+      team = await Team.findOne({ domains: parts[1] }).exec();
+    }
+  }
+
+  if (!team) {
+    return res.status(400).json({ message: 'Unable to determine team for user' });
+  }
+
+  // Enforce license seat limits
+  const memberCount = await User.countDocuments({ team: team._id });
+  if (memberCount >= team.seats) {
+    return res.status(400).json({ message: 'No available seats for this team' });
+  }
+
+  const newUser = new User({
+    username,
+    password: hashed,
+    role: 'user',
+    team: team._id,
+    allowedContacts: []
+  });
   await newUser.save();
 
-  res.json({ id: newUser._id, username: newUser.username, role: newUser.role });
+  res.json({ id: newUser._id, username: newUser.username, role: newUser.role, team: team.name });
 });
 
 export default router;

--- a/backend/src/routes/teams.ts
+++ b/backend/src/routes/teams.ts
@@ -1,0 +1,28 @@
+import { Router } from 'express';
+import { Team } from '../models/team';
+import { authMiddleware, requireRole, AuthRequest } from '../middleware/authMiddleware';
+
+const router = Router();
+
+// All team operations require authentication
+router.use(authMiddleware);
+
+/**
+ * List all teams. Only admins may access this endpoint.
+ */
+router.get('/', requireRole(['admin']), async (_req, res) => {
+  const list = await Team.find().exec();
+  res.json(list);
+});
+
+/**
+ * Create a new team with a name, domain list and seat count.
+ */
+router.post('/', requireRole(['admin']), async (req: AuthRequest, res) => {
+  const { name, domains, seats } = req.body;
+  const team = new Team({ name, domains, seats });
+  await team.save();
+  res.status(201).json(team);
+});
+
+export default router;

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -4,6 +4,23 @@ import { User } from '../models/user';
 import { DirectMessage } from '../models/directMessage';
 import { isOnline } from '../presence';
 
+/**
+ * Determine whether two users may exchange direct messages. Users in the same
+ * team are always allowed. Cross-team messages require the recipient to be
+ * listed in the sender's allowedContacts array.
+ */
+async function canMessage(sender: string, recipient: string): Promise<boolean> {
+  const [from, to] = await Promise.all([
+    User.findOne({ username: sender }).exec(),
+    User.findOne({ username: recipient }).exec()
+  ]);
+  if (!from || !to) return false;
+  // Same-team communication is permitted by default
+  if (String(from.team) === String(to.team)) return true;
+  // Cross-team messages require explicit permission
+  return from.allowedContacts.some(id => String(id) === String(to._id));
+}
+
 const router = Router();
 
 // Ensure all routes in this file require authentication
@@ -12,8 +29,10 @@ router.use(authMiddleware);
 /**
  * Get a list of all registered users along with their online status.
  */
-router.get('/', async (_req, res) => {
-  const users = await User.find().select('username').exec();
+router.get('/', async (req: AuthRequest, res) => {
+  // Only list members of the same team so workspaces remain isolated
+  const teamId = req.user!.team;
+  const users = await User.find({ team: teamId }).select('username').exec();
   const result = users.map(u => ({
     username: u.username,
     online: isOnline(u.username)
@@ -27,6 +46,11 @@ router.get('/', async (_req, res) => {
 router.get('/conversation/:user', async (req: AuthRequest, res) => {
   const other = req.params.user;
   const current = req.user!.username;
+
+  // Ensure the two users are allowed to exchange messages
+  if (!(await canMessage(current, other))) {
+    return res.status(403).json({ message: 'Messaging not permitted' });
+  }
 
   // Mark messages from the other user as seen once this conversation is opened
   const unseen = await DirectMessage.updateMany(
@@ -57,6 +81,10 @@ router.post('/conversation/:user', async (req: AuthRequest, res) => {
   const other = req.params.user;
   const current = req.user!.username;
   const { text } = req.body;
+
+  if (!(await canMessage(current, other))) {
+    return res.status(403).json({ message: 'Messaging not permitted' });
+  }
 
   const msg = new DirectMessage({ from: current, to: other, text });
   await msg.save();
@@ -104,6 +132,38 @@ router.post('/read/:user', async (req: AuthRequest, res) => {
   }
 
   res.json({ count: updated.modifiedCount });
+});
+
+/**
+ * Allow cross-team direct messages from another user. Only the caller's
+ * allowedContacts array is updated so both sides must opt in separately.
+ */
+router.post('/contacts/:user', async (req: AuthRequest, res) => {
+  const current = await User.findById(req.user!.id).exec();
+  const other = await User.findOne({ username: req.params.user }).exec();
+  if (!current || !other) {
+    return res.status(404).json({ message: 'User not found' });
+  }
+  if (String(current.team) === String(other.team)) {
+    return res.status(400).json({ message: 'User already in your team' });
+  }
+  if (!current.allowedContacts.some(id => String(id) === String(other._id))) {
+    current.allowedContacts.push(other._id as any);
+    await current.save();
+  }
+  res.json({ message: 'Contact added' });
+});
+
+// Remove a previously allowed contact
+router.delete('/contacts/:user', async (req: AuthRequest, res) => {
+  const current = await User.findById(req.user!.id).exec();
+  const other = await User.findOne({ username: req.params.user }).exec();
+  if (!current || !other) {
+    return res.status(404).json({ message: 'User not found' });
+  }
+  current.allowedContacts = current.allowedContacts.filter(id => String(id) !== String(other._id));
+  await current.save();
+  res.json({ message: 'Contact removed' });
 });
 
 export default router;

--- a/backend/src/seedUsers.ts
+++ b/backend/src/seedUsers.ts
@@ -1,5 +1,6 @@
 import bcrypt from 'bcrypt';
 import { User } from './models/user';
+import { Team } from './models/team';
 
 /**
  * Ensure a set of demo users exist in the database. Each user has the
@@ -7,12 +8,33 @@ import { User } from './models/user';
  * during demos.
  */
 export async function seedUsers(): Promise<void> {
+  // Create demo teams if needed
+  const [teamA, teamB] = await Promise.all([
+    Team.findOneAndUpdate(
+      { name: 'TeamA' },
+      { name: 'TeamA', domains: ['example.com'], seats: 10 },
+      { upsert: true, new: true }
+    ),
+    Team.findOneAndUpdate(
+      { name: 'TeamB' },
+      { name: 'TeamB', domains: ['example.org'], seats: 10 },
+      { upsert: true, new: true }
+    )
+  ]);
+
   const names = ['jack', 'jill', 'alice', 'bob', 'eve'];
   for (const username of names) {
     // Only create the account if it doesn't already exist
     if (!(await User.exists({ username }))) {
       const hashed = await bcrypt.hash(username, 10);
-      const user = new User({ username, password: hashed, role: 'user' });
+      const team = username === 'alice' || username === 'bob' || username === 'eve' ? teamB : teamA;
+      const user = new User({
+        username,
+        password: hashed,
+        role: 'user',
+        team: team._id,
+        allowedContacts: []
+      });
       await user.save();
     }
   }


### PR DESCRIPTION
## Summary
- add Team and TeamInvitation models
- extend User with team membership and cross-team contact list
- integrate teams into auth signup and login JWTs
- enforce cross-team messaging rules and provide contact management APIs
- add Teams CRUD endpoints and demo data seeding

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68815f67e5d48328a14b193bcdcd7c66