### PR TITLE
Add admin config API and setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,26 @@ export DB_URI="mongodb://localhost:27017/dash"
 
 Running `npm run db:init` will attempt to connect using this value. If the
 connection succeeds, the server can be started normally with `npm start`.
+
+## Setup
+
+1. Copy `backend/.env.example` to `backend/.env` and edit the `DB_URI` to point
+   to your MongoDB instance. Optionally set `JWT_SECRET` for token signing.
+2. Install dependencies and build the backend:
+
+   ```bash
+   cd backend
+   npm install
+   npm run build
+   npm start
+   ```
+
+## Admin Configuration
+
+Administrators can manage runtime settings via the new `/api/admin/config`
+endpoints:
+
+- `POST /api/admin/config` &ndash; create or update a configuration value
+- `GET /api/admin/config` &ndash; list all stored configuration values
+
+These endpoints require an authenticated user with the `admin` role.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import timesheetRoutes from './routes/timesheets';
 import leaveRoutes from './routes/leaves';
 import userRoutes from './routes/users';
 import teamRoutes from './routes/teams';
+import adminRoutes from './routes/admin';
 import { connectDB } from './db';
 import { Message } from './models/message';
 import { DirectMessage } from './models/directMessage';
@@ -116,6 +117,7 @@ app.use('/api/timesheets', timesheetRoutes);
 app.use('/api/leaves', leaveRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/teams', teamRoutes);
+app.use('/api/admin', adminRoutes);
 
 // Serve static frontend files. The path is resolved relative to the compiled
 // JavaScript location so it works when running from the 'dist' directory.

--- a/backend/src/models/config.ts
+++ b/backend/src/models/config.ts
@@ -1,0 +1,18 @@
+import { Schema, model, Document } from 'mongoose';
+
+/**
+ * Configuration values stored as key/value pairs.
+ * This allows runtime settings to be changed by admins
+ * without modifying environment variables.
+ */
+export interface IConfig extends Document {
+  key: string;
+  value: string;
+}
+
+const ConfigSchema = new Schema<IConfig>({
+  key: { type: String, required: true, unique: true },
+  value: { type: String, required: true }
+});
+
+export const Config = model<IConfig>('Config', ConfigSchema);

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import { authMiddleware, requireRole } from '../middleware/authMiddleware';
+import { Config } from '../models/config';
+
+const router = Router();
+
+// All admin routes require authentication and admin role
+router.use(authMiddleware, requireRole(['admin']));
+
+/**
+ * Retrieve all configuration key/value pairs.
+ */
+router.get('/config', async (_req, res) => {
+  const list = await Config.find().exec();
+  res.json(list);
+});
+
+/**
+ * Set a configuration value. Existing keys are updated and new
+ * keys are created automatically.
+ */
+router.post('/config', async (req, res) => {
+  const { key, value } = req.body;
+  if (!key || value === undefined) {
+    return res.status(400).json({ message: 'key and value required' });
+  }
+
+  const item = await Config.findOneAndUpdate(
+    { key },
+    { value },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  ).exec();
+
+  res.json(item);
+});
+
+export default router;

--- a/backend/test/admin.test.ts
+++ b/backend/test/admin.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import { app } from '../src/index';
+import { connectDB } from '../src/db';
+import { User } from '../src/models/user';
+import { Team } from '../src/models/team';
+
+let mongo: MongoMemoryServer;
+let adminToken: string;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  process.env.DB_URI = mongo.getUri();
+  await connectDB();
+
+  const team = new Team({ name: 'Admins', domains: [], seats: 2 });
+  await team.save();
+
+  const hashed = await bcrypt.hash('password', 10);
+  const admin = new User({ username: 'admin', password: hashed, role: 'admin', team: team._id });
+  await admin.save();
+
+  adminToken = jwt.sign(
+    { id: admin.id, username: admin.username, role: admin.role, team: team.id },
+    'secret',
+    { expiresIn: '1h' }
+  );
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+/** Verify config values can be created and listed */
+test('admin config endpoints', async () => {
+  const create = await request(app)
+    .post('/api/admin/config')
+    .set('Authorization', `Bearer ${adminToken}`)
+    .send({ key: 'maintenance', value: 'false' });
+  expect(create.status).toBe(200);
+  expect(create.body.value).toBe('false');
+
+  const list = await request(app)
+    .get('/api/admin/config')
+    .set('Authorization', `Bearer ${adminToken}`);
+  expect(list.body.find((c: any) => c.key === 'maintenance')).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- add setup and admin configuration documentation
- add model and route for persistent configuration
- expose `/api/admin/config` endpoints
- test new admin config endpoints

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688219e855b8832890631e434bec9dcb