### PR TITLE
Update API base URL handling for remote login

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ Dash is an example enterprise web platform demonstrating several features:
    npm run build
    npm start
    ```
-   Browse to `http://localhost:3000` and the web interface should load
-   without a separate static file server.
-   The JavaScript code assumes the API is available on `http://localhost:3000`.
-   If your backend runs elsewhere, update `API_BASE_URL` in
-   `frontend/js/app.js` accordingly so requests reach the correct server.
+  Browse to `http://localhost:3000` and the web interface should load
+  without a separate static file server.
+  The frontend now uses `window.location.origin` for API requests so it
+  automatically points to the host that served the page. If your backend
+  runs on a different host or port, update `API_BASE_URL` in
+  `frontend/js/app.js` accordingly.
 
 ### Docker
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,8 +1,10 @@
-// Base URL for API requests. The backend runs on localhost:3000 when
-// developing locally, so all API calls target that server regardless of
-// which port the frontend is served from. Update this value if your
-// backend listens on a different host or port.
-const API_BASE_URL = 'http://localhost:3000';
+// Base URL for API requests. By default the frontend assumes the backend
+// is reachable from the same host/port it was served from. Using
+// `window.location.origin` ensures requests are made to whichever server
+// delivered the page, allowing the UI to work when accessed remotely.
+// If your backend runs on a different host or port, replace this value
+// with the appropriate URL (e.g. 'http://192.168.1.5:3000').
+const API_BASE_URL = window.location.origin;
 
 // Promise used to ensure the Socket.IO client library is loaded before
 // attempting to create a connection. If the script tag included in the


### PR DESCRIPTION
## Summary
- make the frontend use `window.location.origin` so API requests work from remote machines
- update docs describing new default and how to override

## Testing
- `npm install` within `backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68821f360418832893ff49a6eeb5967d