### PR TITLE
Add team creation to signup and pricing page

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -42,9 +42,11 @@ router.post('/login', async (req, res) => {
   });
 });
 
-// Sign up endpoint to create a user document
+// Sign up endpoint to create a user document. The request may optionally
+// include a team ID or invitation token to join an existing team. If a
+// `teamName` is supplied, a new team will be created on the fly.
 router.post('/signup', async (req, res) => {
-  const { username, password, teamId, token } = req.body;
+  const { username, password, teamId, token, teamName } = req.body;
 
   // Fail if the username already exists
   if (await User.exists({ username })) {
@@ -70,6 +72,12 @@ router.post('/signup', async (req, res) => {
   } else if (teamId) {
     // Directly specify a team by id
     team = await Team.findById(teamId).exec();
+  } else if (teamName) {
+    // No team was provided so create one using the supplied name
+    // Domains and seat count could also be collected here but are
+    // omitted for simplicity.
+    team = new Team({ name: teamName, domains: [], seats: 5 });
+    await team.save();
   } else {
     // Fallback to domain based matching
     const parts = username.split('@');

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -10,6 +10,7 @@
   <header>
     <nav>
       <strong>Dash</strong>
+      <a href="pricing.html">Pricing</a>
       <a href="dashboard.html">Dashboard</a>
       <a href="#" onclick="logout()">Logout</a>
     </nav>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -10,6 +10,7 @@
   <header>
     <nav>
       <strong>Dash</strong>
+      <a href="pricing.html">Pricing</a>
       <a id="adminLink" href="admin.html" class="hidden">Admin</a>
       <a href="#" onclick="logout()">Logout</a>
     </nav>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,13 +11,15 @@
   <header>
     <nav>
       <strong>Dash</strong>
+      <a href="pricing.html">Pricing</a>
     </nav>
   </header>
 
-  <!-- Hero section shown to unauthenticated users -->
+  <!-- Hero section acts as a welcome splash screen for visitors -->
   <section class="hero">
     <h1>Welcome to Dash</h1>
     <p>The platform for all your project and communication needs.</p>
+    <p>Collaborate with your team, track projects and chat in real time.</p>
     <div>
       <a href="login.html"><button>Login</button></a>
       <a href="signup.html"><button>Sign Up</button></a>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -109,11 +109,16 @@ function login() {
 function signup() {
   const username = document.getElementById('signupUsername').value;
   const password = document.getElementById('signupPassword').value;
+  const teamName = document.getElementById('signupTeamName').value;
+  const token = document.getElementById('signupToken').value;
 
+  // Send the collected details to the signup endpoint. Team name will trigger
+  // creation of a new team while an invite token lets the user join an existing
+  // one.
   fetch(`${API_BASE_URL}/api/auth/signup`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, password })
+    body: JSON.stringify({ username, password, teamName, token })
   })
     .then(r => r.ok ? r.json() : r.json().then(d => Promise.reject(d.message || 'Signup failed')))
     .then(u => {

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -10,6 +10,7 @@
   <header>
     <nav>
       <strong>Dash</strong>
+      <a href="pricing.html">Pricing</a>
     </nav>
   </header>
 

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pricing - Dash</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <nav>
+      <strong>Dash</strong>
+      <a href="login.html">Login</a>
+      <a href="signup.html">Sign Up</a>
+    </nav>
+  </header>
+
+  <section class="hero">
+    <h1>Pricing</h1>
+    <p>Subscription plans and payment options coming soon.</p>
+  </section>
+</body>
+</html>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -10,6 +10,7 @@
   <header>
     <nav>
       <strong>Dash</strong>
+      <a href="pricing.html">Pricing</a>
     </nav>
   </header>
 
@@ -18,6 +19,9 @@
     <h1>Create Account</h1>
     <input id="signupUsername" placeholder="Username" />
     <input id="signupPassword" placeholder="Password" type="password" />
+    <input id="signupTeamName" placeholder="Team name (new teams)" />
+    <input id="signupToken" placeholder="Invite token" />
+    <input placeholder="Payment details (coming soon)" disabled />
     <button onclick="signup()">Sign Up</button>
     <p id="signupStatus"></p>
     <p>Already have an account? <a href="login.html">Login</a></p>


### PR DESCRIPTION
## Summary
- allow new teams to be created during signup
- capture optional team name and invite token on signup page
- create placeholder pricing page and update navigation links
- show a welcome splash screen on the landing page

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68822955b0588328a428d3fb3a591f1c