### PR TITLE
Add basic CRM contact management

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Dash is an example enterprise web platform demonstrating several features:
 
 - Instant messaging with multiple channels, presence indicators and message editing
-- Basic CRM and project/program management
+- Basic CRM with contact management and project/program tracking
 - Timesheets and leave requests
 - Team management with seat limits and email invitations
 - Simple sign-up flow that creates teams with dummy payment processing

--- a/backend/src/routes/crm.ts
+++ b/backend/src/routes/crm.ts
@@ -13,6 +13,15 @@ router.get('/', async (_, res) => {
   res.json(list);
 });
 
+// Retrieve a single contact by identifier
+router.get('/:id', async (req, res) => {
+  const contact = await Contact.findById(req.params.id).exec();
+  if (!contact) {
+    return res.status(404).json({ message: 'Contact not found' });
+  }
+  res.json(contact);
+});
+
 // Add a new contact or update an existing one
 router.post('/', requireRole(['admin', 'teamAdmin']), async (req, res) => {
   const { id, ...data } = req.body;
@@ -26,6 +35,15 @@ router.post('/', requireRole(['admin', 'teamAdmin']), async (req, res) => {
   const contact = new Contact(data);
   await contact.save();
   res.status(201).json(contact);
+});
+
+// Permanently remove a contact
+router.delete('/:id', requireRole(['admin', 'teamAdmin']), async (req, res) => {
+  const del = await Contact.findByIdAndDelete(req.params.id).exec();
+  if (!del) {
+    return res.status(404).json({ message: 'Contact not found' });
+  }
+  res.json({ message: 'Contact deleted' });
 });
 
 export default router;

--- a/backend/test/crm.test.ts
+++ b/backend/test/crm.test.ts
@@ -1,0 +1,71 @@
+import request from 'supertest';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import { app } from '../src/index';
+import { connectDB } from '../src/db';
+import { Team } from '../src/models/team';
+import { User } from '../src/models/user';
+
+let mongo: MongoMemoryServer;
+let adminToken: string;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  process.env.DB_URI = mongo.getUri();
+  await connectDB();
+
+  const team = new Team({ name: 'Admins', domains: [], seats: 2 });
+  await team.save();
+
+  const hashed = await bcrypt.hash('secret', 10);
+  const admin = new User({ username: 'admin', password: hashed, role: 'admin', team: team._id });
+  await admin.save();
+  adminToken = jwt.sign(
+    { id: admin.id, username: admin.username, role: admin.role, team: team.id },
+    'secret',
+    { expiresIn: '1h' }
+  );
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+/** Verify contacts can be created, retrieved and deleted */
+test('crm contact lifecycle', async () => {
+  const create = await request(app)
+    .post('/api/crm')
+    .set('Authorization', `Bearer ${adminToken}`)
+    .send({ name: 'Acme', email: 'contact@example.com', phone: '123' });
+  expect(create.status).toBe(201);
+  const id = create.body._id;
+
+  const list = await request(app)
+    .get('/api/crm')
+    .set('Authorization', `Bearer ${adminToken}`);
+  expect(list.body.find((c: any) => c._id === id)).toBeTruthy();
+
+  const single = await request(app)
+    .get(`/api/crm/${id}`)
+    .set('Authorization', `Bearer ${adminToken}`);
+  expect(single.body.email).toBe('contact@example.com');
+
+  const update = await request(app)
+    .post('/api/crm')
+    .set('Authorization', `Bearer ${adminToken}`)
+    .send({ id, name: 'Acme Updated', email: 'contact@example.com', phone: '456' });
+  expect(update.body.name).toBe('Acme Updated');
+
+  const del = await request(app)
+    .delete(`/api/crm/${id}`)
+    .set('Authorization', `Bearer ${adminToken}`);
+  expect(del.status).toBe(200);
+
+  const missing = await request(app)
+    .get(`/api/crm/${id}`)
+    .set('Authorization', `Bearer ${adminToken}`);
+  expect(missing.status).toBe(404);
+});

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -48,7 +48,14 @@
       <!-- Placeholder sections for future tools -->
       <section id="crm" class="hidden">
         <h2>CRM</h2>
-        <p>CRM functionality coming soon.</p>
+        <form id="contactForm" onsubmit="saveContact(event)">
+          <input id="contactId" type="hidden" />
+          <input id="contactName" placeholder="Name" required />
+          <input id="contactEmail" placeholder="Email" required />
+          <input id="contactPhone" placeholder="Phone" required />
+          <button type="submit">Save</button>
+        </form>
+        <table class="admin-table" id="contactTable"></table>
       </section>
       <section id="timesheets" class="hidden">
         <h2>Timesheets</h2>


### PR DESCRIPTION
## Summary
- support retrieving and deleting CRM contacts via new API routes
- implement contact list and form in the dashboard
- load contacts when selecting the CRM tool
- update README feature list
- test CRM contact lifecycle

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882562afad0832898fc787dd8dcf3a0