### PR TITLE
Add basic project management

### DIFF
--- a/backend/src/models/project.ts
+++ b/backend/src/models/project.ts
@@ -1,22 +1,35 @@
-import { Schema, model, Document } from 'mongoose';
+import { Schema, model, Document, Types } from 'mongoose';
+import { IWorkPackage, WorkPackage } from './workPackage';
 
 /**
- * Work project information.
+ * Work project information including nested work packages and tasks.
  */
 export interface IProject extends Document {
   name: string;
   description?: string;
+  owner: string;
+  start: Date;
+  end: Date;
+  hours: number;
+  cost: number;
   status: 'todo' | 'in-progress' | 'done';
+  workPackages: Types.DocumentArray<IWorkPackage>;
 }
 
 const ProjectSchema = new Schema<IProject>({
   name: { type: String, required: true },
   description: String,
+  owner: { type: String, required: true },
+  start: Date,
+  end: Date,
+  hours: Number,
+  cost: Number,
   status: {
     type: String,
     enum: ['todo', 'in-progress', 'done'],
     default: 'todo'
-  }
+  },
+  workPackages: [WorkPackage.schema]
 });
 
 export const Project = model<IProject>('Project', ProjectSchema);

--- a/backend/src/models/task.ts
+++ b/backend/src/models/task.ts
@@ -1,0 +1,24 @@
+import { Schema, model, Document } from 'mongoose';
+
+/**
+ * Individual task belonging to a work package.
+ */
+export interface ITask extends Document {
+  name: string;
+  owner: string;
+  start: Date;
+  end: Date;
+  hours: number;
+  cost: number;
+}
+
+const TaskSchema = new Schema<ITask>({
+  name: { type: String, required: true },
+  owner: { type: String, required: true },
+  start: Date,
+  end: Date,
+  hours: Number,
+  cost: Number
+});
+
+export const Task = model<ITask>('Task', TaskSchema);

--- a/backend/src/models/workPackage.ts
+++ b/backend/src/models/workPackage.ts
@@ -1,0 +1,27 @@
+import { Schema, model, Document, Types } from 'mongoose';
+import { ITask, Task } from './task';
+
+/**
+ * Work package groups multiple tasks under a project.
+ */
+export interface IWorkPackage extends Document {
+  name: string;
+  owner: string;
+  start: Date;
+  end: Date;
+  hours: number;
+  cost: number;
+  tasks: Types.Array<ITask>;
+}
+
+const WorkPackageSchema = new Schema<IWorkPackage>({
+  name: { type: String, required: true },
+  owner: { type: String, required: true },
+  start: Date,
+  end: Date,
+  hours: Number,
+  cost: Number,
+  tasks: [Task.schema]
+});
+
+export const WorkPackage = model<IWorkPackage>('WorkPackage', WorkPackageSchema);

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -7,24 +7,70 @@ const router = Router();
 // All project routes require authentication
 router.use(authMiddleware);
 
-// Fetch all projects in the system
+// Fetch all projects
 router.get('/', async (_, res) => {
   const list = await Project.find().exec();
   res.json(list);
 });
 
-// Create a new project or update an existing one
+// Retrieve a single project with nested details
+router.get('/:id', async (req, res) => {
+  const proj = await Project.findById(req.params.id).exec();
+  if (!proj) return res.status(404).json({ message: 'Project not found' });
+  res.json(proj);
+});
+
+// Create or update a project
 router.post('/', requireRole(['admin', 'teamAdmin']), async (req, res) => {
   const { id, ...data } = req.body;
 
   if (id) {
-    // Update existing project
     const updated = await Project.findByIdAndUpdate(id, data, { new: true });
     return res.status(201).json(updated);
   }
 
   const project = new Project(data);
   await project.save();
+  res.status(201).json(project);
+});
+
+// Remove a project
+router.delete('/:id', requireRole(['admin', 'teamAdmin']), async (req, res) => {
+  const del = await Project.findByIdAndDelete(req.params.id).exec();
+  if (!del) return res.status(404).json({ message: 'Project not found' });
+  res.json({ message: 'Project deleted' });
+});
+
+// Add a work package to a project
+router.post('/:id/workpackages', requireRole(['admin', 'teamAdmin']), async (req, res) => {
+  const project = await Project.findById(req.params.id).exec();
+  if (!project) return res.status(404).json({ message: 'Project not found' });
+  project.workPackages.push(req.body);
+  await project.save();
+  res.status(201).json(project);
+});
+
+// Add a task to a work package and notify the owner
+router.post('/:id/workpackages/:wpId/tasks', requireRole(['admin', 'teamAdmin']), async (req, res) => {
+  const project = await Project.findById(req.params.id).exec();
+  if (!project) return res.status(404).json({ message: 'Project not found' });
+  const wp = project.workPackages.id(req.params.wpId);
+  if (!wp) return res.status(404).json({ message: 'Work package not found' });
+  wp.tasks.push(req.body);
+  await project.save();
+
+  // Notify task owner via direct message channel if socket.io available
+  const io = req.app.get('io');
+  if (io) {
+    io.to(req.body.owner).emit('directMessage', {
+      from: 'system',
+      to: req.body.owner,
+      text: `New task assigned: ${req.body.name}`,
+      createdAt: new Date().toISOString(),
+      isSeen: false
+    });
+  }
+
   res.status(201).json(project);
 });
 

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -63,6 +63,10 @@ header nav a {
   background: #555;
 }
 
+#gantt {
+  margin-top: 1rem;
+}
+
 /* Contextual sidebar shown for the selected tool */
 .context-sidebar {
   width: 200px;

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -23,6 +23,7 @@
       <ul>
         <li id="tool-messages" class="active" onclick="selectTool('messages')">💬</li>
         <li id="tool-crm" onclick="selectTool('crm')">CRM</li>
+        <li id="tool-projects" onclick="selectTool('projects')">Projects</li>
         <li id="tool-timesheets" onclick="selectTool('timesheets')">TS</li>
         <li id="tool-recruit" onclick="selectTool('recruit')">HR</li>
       </ul>
@@ -58,6 +59,22 @@
           <button type="submit">Save</button>
         </form>
         <table class="admin-table" id="contactTable"></table>
+      </section>
+      <section id="projects" class="hidden">
+        <h2>Projects</h2>
+        <form id="projectForm" onsubmit="saveProject(event)">
+          <input id="projectId" type="hidden" />
+          <input id="projectName" placeholder="Project name" required />
+          <input id="projectOwner" placeholder="Owner" required />
+          <input id="projectStart" type="date" />
+          <input id="projectEnd" type="date" />
+          <input id="projectHours" type="number" placeholder="Hours" />
+          <input id="projectCost" type="number" placeholder="£ Cost" />
+          <textarea id="projectDesc" placeholder="Description"></textarea>
+          <button type="submit">Save</button>
+        </form>
+        <div id="gantt"></div>
+        <table class="admin-table" id="projectTable"></table>
       </section>
       <section id="timesheets" class="hidden">
         <h2>Timesheets</h2>


### PR DESCRIPTION
## Summary
- add `Projects` menu item with new section for project management
- model projects with nested work packages and tasks
- create CRUD APIs for projects with task notifications via IM
- load projects in dashboard and render a simple gantt chart

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68825b004e988328bb4286d65b08ec60