### PR TITLE
Implement social networking basics

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import userRoutes from './routes/users';
 import teamRoutes from './routes/teams';
 import adminRoutes from './routes/admin';
 import profileRoutes from './routes/profile';
+import socialRoutes from './routes/social';
 import { connectDB } from './db';
 import { Message } from './models/message';
 import { DirectMessage } from './models/directMessage';
@@ -151,6 +152,7 @@ app.use('/api/users', userRoutes);
 app.use('/api/teams', teamRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/profile', profileRoutes);
+app.use('/api/social', socialRoutes);
 
 // Expose uploaded profile photos as static files
 const uploadsDir = path.resolve(__dirname, '..', '..', 'uploads');

--- a/backend/src/models/socialPost.ts
+++ b/backend/src/models/socialPost.ts
@@ -1,0 +1,23 @@
+import { Schema, model, Document, Types } from 'mongoose';
+import { IUser } from './user';
+
+/**
+ * Short status update made by a user. Each post references the
+ * author for quick population when listing the feed.
+ */
+export interface ISocialPost extends Document {
+  /** User that created the post */
+  author: Types.ObjectId | IUser;
+  /** Post contents */
+  text: string;
+  /** Timestamp of creation */
+  createdAt: Date;
+}
+
+const SocialPostSchema = new Schema<ISocialPost>({
+  author: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  text: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now }
+});
+
+export const SocialPost = model<ISocialPost>('SocialPost', SocialPostSchema);

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -13,6 +13,10 @@ export interface IUser extends Document {
   team?: Types.ObjectId;
   /** Users from other teams allowed to message this user */
   allowedContacts: Types.ObjectId[];
+  /** Users this account is following */
+  following: Types.ObjectId[];
+  /** Users that follow this account */
+  followers: Types.ObjectId[];
 }
 
 const UserSchema = new Schema<IUser>({
@@ -21,7 +25,10 @@ const UserSchema = new Schema<IUser>({
   role: { type: String, enum: ['user', 'teamAdmin', 'admin'], default: 'user' },
   team: { type: Schema.Types.ObjectId, ref: 'Team' },
   // Cross-team contacts who may exchange direct messages
-  allowedContacts: [{ type: Schema.Types.ObjectId, ref: 'User' }]
+  allowedContacts: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+  // Social relationships
+  following: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+  followers: [{ type: Schema.Types.ObjectId, ref: 'User' }]
 });
 
 export const User = model<IUser>('User', UserSchema);

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -112,7 +112,9 @@ router.post('/signup', async (req, res) => {
     password: hashed,
     role: 'user',
     team: team._id,
-    allowedContacts: []
+    allowedContacts: [],
+    following: [],
+    followers: []
   });
   await newUser.save();
 

--- a/backend/src/routes/social.ts
+++ b/backend/src/routes/social.ts
@@ -1,0 +1,102 @@
+import { Router } from 'express';
+import { authMiddleware, AuthRequest } from '../middleware/authMiddleware';
+import { SocialPost } from '../models/socialPost';
+import { User } from '../models/user';
+
+const router = Router();
+
+// Require authentication for all social endpoints
+router.use(authMiddleware);
+
+/**
+ * Retrieve the latest social posts in reverse chronological order.
+ */
+router.get('/posts', async (_req, res) => {
+  const posts = await SocialPost.find()
+    .sort({ createdAt: -1 })
+    .populate('author', 'username')
+    .exec();
+  res.json(posts);
+});
+
+/**
+ * Create a new status post by the logged in user.
+ */
+router.post('/posts', async (req: AuthRequest, res) => {
+  const text = req.body.text;
+  if (!text) {
+    return res.status(400).json({ message: 'Text required' });
+  }
+  const post = new SocialPost({ author: req.user!.id, text });
+  await post.save();
+  const populated = await post.populate('author', 'username');
+  res.status(201).json(populated);
+});
+
+/**
+ * Follow another user by their id.
+ */
+router.post('/follow/:id', async (req: AuthRequest, res) => {
+  const targetId = req.params.id;
+  if (targetId === req.user!.id) {
+    return res.status(400).json({ message: 'Cannot follow yourself' });
+  }
+  const [current, target] = await Promise.all([
+    User.findById(req.user!.id).exec(),
+    User.findById(targetId).exec()
+  ]);
+  if (!current || !target) {
+    return res.status(404).json({ message: 'User not found' });
+  }
+  if (!current.following.some(id => String(id) === targetId)) {
+    current.following.push(target._id as any);
+    await current.save();
+  }
+  if (!target.followers.some(id => String(id) === String(current._id))) {
+    target.followers.push(current._id as any);
+    await target.save();
+  }
+  res.json({ message: 'Followed' });
+});
+
+/**
+ * Unfollow a previously followed user.
+ */
+router.delete('/follow/:id', async (req: AuthRequest, res) => {
+  const targetId = req.params.id;
+  const [current, target] = await Promise.all([
+    User.findById(req.user!.id).exec(),
+    User.findById(targetId).exec()
+  ]);
+  if (!current || !target) {
+    return res.status(404).json({ message: 'User not found' });
+  }
+  current.following = current.following.filter(id => String(id) !== targetId);
+  target.followers = target.followers.filter(id => String(id) !== String(current._id));
+  await Promise.all([current.save(), target.save()]);
+  res.json({ message: 'Unfollowed' });
+});
+
+/**
+ * Get the list of users the specified account is following.
+ */
+router.get('/following/:id', async (req, res) => {
+  const user = await User.findById(req.params.id)
+    .populate('following', 'username')
+    .exec();
+  if (!user) return res.status(404).json({ message: 'User not found' });
+  res.json(user.following);
+});
+
+/**
+ * Get the followers of the specified user.
+ */
+router.get('/followers/:id', async (req, res) => {
+  const user = await User.findById(req.params.id)
+    .populate('followers', 'username')
+    .exec();
+  if (!user) return res.status(404).json({ message: 'User not found' });
+  res.json(user.followers);
+});
+
+export default router;

--- a/backend/src/seedUsers.ts
+++ b/backend/src/seedUsers.ts
@@ -41,7 +41,9 @@ export async function seedUsers(): Promise<void> {
       password: hashed,
       role: 'admin',
       team: adminTeam._id,
-      allowedContacts: []
+      allowedContacts: [],
+      following: [],
+      followers: []
     });
     await adminUser.save();
   }
@@ -57,7 +59,9 @@ export async function seedUsers(): Promise<void> {
         password: hashed,
         role: 'user',
         team: team._id,
-        allowedContacts: []
+        allowedContacts: [],
+        following: [],
+        followers: []
       });
       await user.save();
     }

--- a/backend/test/social.test.ts
+++ b/backend/test/social.test.ts
@@ -1,0 +1,76 @@
+import request from 'supertest';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import mongoose from 'mongoose';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+
+jest.setTimeout(20000);
+import { app } from '../src/index';
+import { connectDB } from '../src/db';
+import { User } from '../src/models/user';
+
+let mongo: MongoMemoryServer;
+let tokenA: string;
+let tokenB: string;
+let userAId: string;
+let userBId: string;
+
+beforeAll(async () => {
+  mongo = await MongoMemoryServer.create();
+  process.env.DB_URI = mongo.getUri();
+  await connectDB();
+
+  const hashedA = await bcrypt.hash('a', 10);
+  const a = await new User({
+    username: 'a',
+    password: hashedA,
+    role: 'user',
+    allowedContacts: [],
+    following: [],
+    followers: []
+  }).save();
+  const hashedB = await bcrypt.hash('b', 10);
+  const b = await new User({
+    username: 'b',
+    password: hashedB,
+    role: 'user',
+    allowedContacts: [],
+    following: [],
+    followers: []
+  }).save();
+
+  userAId = a.id;
+  userBId = b.id;
+  tokenA = jwt.sign({ id: a.id, username: a.username, role: a.role }, 'secret');
+  tokenB = jwt.sign({ id: b.id, username: b.username, role: b.role }, 'secret');
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongo.stop();
+});
+
+/** Verify posts can be created and users followed */
+test('post creation and follow', async () => {
+  const create = await request(app)
+    .post('/api/social/posts')
+    .set('Authorization', `Bearer ${tokenA}`)
+    .send({ text: 'hello world' });
+  expect(create.status).toBe(201);
+  expect(create.body.text).toBe('hello world');
+
+  const list = await request(app)
+    .get('/api/social/posts')
+    .set('Authorization', `Bearer ${tokenA}`);
+  expect(list.body.length).toBe(1);
+
+  const follow = await request(app)
+    .post(`/api/social/follow/${userBId}`)
+    .set('Authorization', `Bearer ${tokenA}`);
+  expect(follow.status).toBe(200);
+
+  const following = await request(app)
+    .get(`/api/social/following/${userAId}`)
+    .set('Authorization', `Bearer ${tokenA}`);
+  expect(following.body[0].username).toBe('b');
+});

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -27,6 +27,7 @@
         <li id="tool-projects" onclick="selectTool('projects')">Projects</li>
         <li id="tool-timesheets" onclick="selectTool('timesheets')">TS</li>
         <li id="tool-recruit" onclick="selectTool('recruit')">HR</li>
+        <li id="tool-social" onclick="selectTool('social')">Social</li>
       </ul>
     </nav>
 
@@ -84,6 +85,14 @@
       <section id="recruit" class="hidden">
         <h2>Recruitment</h2>
         <p>Recruitment functionality coming soon.</p>
+      </section>
+      <section id="social" class="hidden">
+        <h2>Social</h2>
+        <form id="postForm" onsubmit="savePost(event)">
+          <textarea id="postText" placeholder="Share an update" required></textarea>
+          <button type="submit">Post</button>
+        </form>
+        <ul id="postList"></ul>
       </section>
     </main>
   </div>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -73,6 +73,10 @@ function selectTool(tool) {
     resetProjectForm();
   }
 
+  if (tool === 'social') {
+    loadPosts();
+  }
+
   // Display the relevant section in the main area
   document.querySelectorAll('.content > section').forEach(sec => sec.classList.add('hidden'));
   const activeSection = document.getElementById(tool);
@@ -648,6 +652,42 @@ function renderGantt(tasks) {
   } else {
     new Gantt(area, tasks);
   }
+}
+
+// ----------------------- Social helpers -----------------------
+
+// Retrieve all posts for the social feed
+function loadPosts() {
+  fetch(`${API_BASE_URL}/api/social/posts`, {
+    headers: { Authorization: `Bearer ${currentUser.token}` }
+  })
+    .then(r => r.json())
+    .then(list => {
+      const posts = document.getElementById('postList');
+      posts.innerHTML = '';
+      list.forEach(p => {
+        const li = document.createElement('li');
+        li.textContent = `${p.author.username}: ${p.text}`;
+        posts.appendChild(li);
+      });
+    });
+}
+
+// Submit a new social post
+function savePost(e) {
+  e.preventDefault();
+  const text = document.getElementById('postText').value;
+  fetch(`${API_BASE_URL}/api/social/posts`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${currentUser.token}`
+    },
+    body: JSON.stringify({ text })
+  }).then(() => {
+    document.getElementById('postText').value = '';
+    loadPosts();
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- add follow/following fields to user model
- implement new `SocialPost` model
- create `/api/social` routes for posts and follow management
- integrate new routes with Express app
- seed and sign-up new users with empty social arrays
- add frontend Social section and related JS helpers
- include tests covering new endpoints

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a92a0d3883289b70a1e15dae211d