### PR TITLE
Add CRUD workflow for projects, work packages and tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ Dash is an example enterprise web platform demonstrating several features:
 
 - Instant messaging with multiple channels, presence indicators and message editing
 - Basic CRM with contact management, company/notes fields and project/program tracking
+- Full project management with work packages and tasks
 - Timesheets and leave requests
 - Team management with seat limits and email invitations
 - Simple sign-up flow that creates teams with dummy payment processing
 - Role-based authentication with admin, team admin and user levels
-- Browser-based UI designed to be responsive and mobile friendly
+- Browser-based UI designed to be responsive and mobile friendly with a consistent card layout
 - Dockerised backend for easy deployment
 
 ## Getting Started

--- a/backend/src/models/workPackage.ts
+++ b/backend/src/models/workPackage.ts
@@ -11,7 +11,7 @@ export interface IWorkPackage extends Document {
   end: Date;
   hours: number;
   cost: number;
-  tasks: Types.Array<ITask>;
+  tasks: Types.DocumentArray<ITask>;
 }
 
 const WorkPackageSchema = new Schema<IWorkPackage>({

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -74,4 +74,79 @@ router.post('/:id/workpackages/:wpId/tasks', requireRole(['admin', 'teamAdmin'])
   res.status(201).json(project);
 });
 
+// Retrieve all work packages for a project
+router.get('/:id/workpackages', async (req, res) => {
+  const project = await Project.findById(req.params.id).exec();
+  if (!project) return res.status(404).json({ message: 'Project not found' });
+  res.json(project.workPackages);
+});
+
+// Update details for a specific work package
+router.patch('/:id/workpackages/:wpId', requireRole(['admin', 'teamAdmin']), async (req, res) => {
+  const project = await Project.findById(req.params.id).exec();
+  if (!project) return res.status(404).json({ message: 'Project not found' });
+  const wp = project.workPackages.id(req.params.wpId);
+  if (!wp) return res.status(404).json({ message: 'Work package not found' });
+  Object.assign(wp, req.body);
+  await project.save();
+  res.json(wp);
+});
+
+// Retrieve a single work package
+router.get('/:id/workpackages/:wpId', async (req, res) => {
+  const project = await Project.findById(req.params.id).exec();
+  if (!project) return res.status(404).json({ message: 'Project not found' });
+  const wp = project.workPackages.id(req.params.wpId);
+  if (!wp) return res.status(404).json({ message: 'Work package not found' });
+  res.json(wp);
+});
+
+// Remove a work package
+router.delete('/:id/workpackages/:wpId', requireRole(['admin', 'teamAdmin']), async (req, res) => {
+  const project = await Project.findById(req.params.id).exec();
+  if (!project) return res.status(404).json({ message: 'Project not found' });
+  const wp = project.workPackages.id(req.params.wpId);
+  if (!wp) return res.status(404).json({ message: 'Work package not found' });
+  wp.deleteOne();
+  await project.save();
+  res.json({ message: 'Work package removed' });
+});
+
+// Update individual tasks within a work package
+router.patch('/:id/workpackages/:wpId/tasks/:taskId', requireRole(['admin', 'teamAdmin']), async (req, res) => {
+  const project = await Project.findById(req.params.id).exec();
+  if (!project) return res.status(404).json({ message: 'Project not found' });
+  const wp = project.workPackages.id(req.params.wpId);
+  if (!wp) return res.status(404).json({ message: 'Work package not found' });
+  const task = wp.tasks.id(req.params.taskId);
+  if (!task) return res.status(404).json({ message: 'Task not found' });
+  Object.assign(task, req.body);
+  await project.save();
+  res.json(task);
+});
+
+// Retrieve a single task from a work package
+router.get('/:id/workpackages/:wpId/tasks/:taskId', async (req, res) => {
+  const project = await Project.findById(req.params.id).exec();
+  if (!project) return res.status(404).json({ message: 'Project not found' });
+  const wp = project.workPackages.id(req.params.wpId);
+  if (!wp) return res.status(404).json({ message: 'Work package not found' });
+  const task = wp.tasks.id(req.params.taskId);
+  if (!task) return res.status(404).json({ message: 'Task not found' });
+  res.json(task);
+});
+
+// Remove an individual task
+router.delete('/:id/workpackages/:wpId/tasks/:taskId', requireRole(['admin', 'teamAdmin']), async (req, res) => {
+  const project = await Project.findById(req.params.id).exec();
+  if (!project) return res.status(404).json({ message: 'Project not found' });
+  const wp = project.workPackages.id(req.params.wpId);
+  if (!wp) return res.status(404).json({ message: 'Work package not found' });
+  const task = wp.tasks.id(req.params.taskId);
+  if (!task) return res.status(404).json({ message: 'Task not found' });
+  task.deleteOne();
+  await project.save();
+  res.json({ message: 'Task removed' });
+});
+
 export default router;

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -29,7 +29,7 @@
       <!-- Configuration management -->
       <section id="config" class="admin-section">
         <h2>Configuration</h2>
-        <form onsubmit="createConfig(event)">
+        <form class="card" onsubmit="createConfig(event)">
           <input id="configKey" placeholder="Key" required />
           <input id="configValue" placeholder="Value" required />
           <button type="submit">Save</button>
@@ -40,7 +40,7 @@
       <!-- Team administration -->
       <section id="teams" class="admin-section hidden">
         <h2>Teams</h2>
-        <form onsubmit="createTeam(event)">
+        <form class="card" onsubmit="createTeam(event)">
           <input id="teamName" placeholder="Name" required />
           <input id="teamDomains" placeholder="Domains (comma separated)" />
           <input id="teamSeats" type="number" placeholder="Seats" value="5" />
@@ -53,7 +53,7 @@
       <!-- User management -->
       <section id="users" class="admin-section hidden">
         <h2>Users</h2>
-        <form onsubmit="createUser(event)">
+        <form class="card" onsubmit="createUser(event)">
           <input id="newUsername" placeholder="Email" required />
           <input id="newPassword" type="password" placeholder="Password" required />
           <select id="newUserTeam"></select>

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -56,6 +56,10 @@ header nav a:hover {
   margin-bottom: 1rem;
 }
 
+.hero .card {
+  width: 300px;
+}
+
 /* Layout for the dashboard with two sidebars similar to Slack/Teams */
 .main-layout {
   display: flex;
@@ -258,5 +262,14 @@ button:hover {
   margin-left: 0.5rem;
   font-size: 0.9rem;
   color: var(--color-muted);
+}
+
+/* Simple card container used to keep forms visually consistent */
+.card {
+  background: var(--color-light);
+  padding: 1rem;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  margin-bottom: 1rem;
 }
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -51,7 +51,7 @@
       <!-- Placeholder sections for future tools -->
       <section id="crm" class="hidden">
         <h2>CRM</h2>
-        <form id="contactForm" onsubmit="saveContact(event)">
+        <form id="contactForm" class="card" onsubmit="saveContact(event)">
           <input id="contactId" type="hidden" />
           <input id="contactName" placeholder="Name" required />
           <input id="contactEmail" placeholder="Email" required />
@@ -65,7 +65,7 @@
       </section>
       <section id="projects" class="hidden">
         <h2>Projects</h2>
-        <form id="projectForm" onsubmit="saveProject(event)">
+        <form id="projectForm" class="card" onsubmit="saveProject(event)">
           <input id="projectId" type="hidden" />
           <input id="projectName" placeholder="Project name" required />
           <input id="projectOwner" placeholder="Owner" required />
@@ -76,6 +76,37 @@
           <textarea id="projectDesc" placeholder="Description"></textarea>
           <button type="submit">Save</button>
         </form>
+
+        <div id="workPackageSection" class="hidden">
+          <h3>Work Packages</h3>
+          <form id="workPackageForm" class="card" onsubmit="saveWorkPackage(event)">
+            <input id="wpProject" type="hidden" />
+            <input id="wpId" type="hidden" />
+            <input id="wpName" placeholder="Work package name" required />
+            <input id="wpOwner" placeholder="Owner" />
+            <input id="wpStart" type="date" />
+            <input id="wpEnd" type="date" />
+            <input id="wpHours" type="number" placeholder="Hours" />
+            <input id="wpCost" type="number" placeholder="£ Cost" />
+            <button type="submit">Save Work Package</button>
+          </form>
+          <table class="admin-table" id="workPackageTable"></table>
+
+          <h4>Tasks</h4>
+          <form id="taskForm" class="card" onsubmit="saveTask(event)">
+            <input id="taskProject" type="hidden" />
+            <input id="taskWp" type="hidden" />
+            <input id="taskId" type="hidden" />
+            <input id="taskName" placeholder="Task name" required />
+            <input id="taskOwner" placeholder="Owner" />
+            <input id="taskStart" type="date" />
+            <input id="taskEnd" type="date" />
+            <input id="taskHours" type="number" placeholder="Hours" />
+            <input id="taskCost" type="number" placeholder="£ Cost" />
+            <button type="submit">Save Task</button>
+          </form>
+          <table class="admin-table" id="taskTable"></table>
+        </div>
         <div id="gantt"></div>
         <table class="admin-table" id="projectTable"></table>
       </section>
@@ -89,7 +120,7 @@
       </section>
       <section id="social" class="hidden">
         <h2>Social</h2>
-        <form id="postForm" onsubmit="savePost(event)">
+        <form id="postForm" class="card" onsubmit="savePost(event)">
           <textarea id="postText" placeholder="Share an update" required></textarea>
           <button type="submit">Post</button>
         </form>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -17,10 +17,12 @@
   <!-- Login form -->
   <section class="hero">
     <h1>Login</h1>
-    <input id="username" placeholder="Username" />
-    <input id="password" placeholder="Password" type="password" />
-    <button onclick="login()">Login</button>
-    <p id="loginStatus"></p>
+    <form class="card" onsubmit="login(); return false;">
+      <input id="username" placeholder="Username" />
+      <input id="password" placeholder="Password" type="password" />
+      <button type="submit">Login</button>
+      <p id="loginStatus"></p>
+    </form>
     <p>Don't have an account? <a href="signup.html">Sign up</a></p>
   </section>
 

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -18,13 +18,13 @@
   <section class="hero">
     <h1>My Profile</h1>
     <img id="profileImage" class="avatar" alt="profile photo" />
-    <form id="profileForm" onsubmit="saveProfile(event)">
+    <form id="profileForm" class="card" onsubmit="saveProfile(event)">
       <input id="profileCareer" placeholder="Career history" />
       <input id="profileEducation" placeholder="Education" />
       <textarea id="profileStatement" placeholder="Personal statement"></textarea>
       <button type="submit">Save</button>
     </form>
-    <form id="photoForm" onsubmit="return false;">
+    <form id="photoForm" class="card" onsubmit="return false;">
       <input id="profilePhoto" type="file" accept="image/*" />
       <button type="button" onclick="uploadPhoto()">Upload Photo</button>
     </form>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -17,14 +17,16 @@
   <!-- Signup form -->
   <section class="hero">
     <h1>Create Account</h1>
-    <input id="signupUsername" placeholder="Username" />
-    <input id="signupPassword" placeholder="Password" type="password" />
-    <input id="signupTeamName" placeholder="Team name (new teams)" />
-    <input id="signupSeats" type="number" placeholder="Seats" min="1" />
-    <input id="signupToken" placeholder="Invite token" />
-    <input placeholder="Payment details (processed on next step)" disabled />
-    <button onclick="signup()">Sign Up</button>
-    <p id="signupStatus"></p>
+    <form class="card" onsubmit="signup(); return false;">
+      <input id="signupUsername" placeholder="Username" />
+      <input id="signupPassword" placeholder="Password" type="password" />
+      <input id="signupTeamName" placeholder="Team name (new teams)" />
+      <input id="signupSeats" type="number" placeholder="Seats" min="1" />
+      <input id="signupToken" placeholder="Invite token" />
+      <input placeholder="Payment details (processed on next step)" disabled />
+      <button type="submit">Sign Up</button>
+      <p id="signupStatus"></p>
+    </form>
     <p>Already have an account? <a href="login.html">Login</a></p>
   </section>
 


### PR DESCRIPTION
## Summary
- expand project management backend endpoints for work packages and tasks
- expose CRUD forms for work packages and tasks in dashboard
- add "card" layout styling for consistent look across forms
- apply card layout to login, signup, admin and profile pages
- document project management in README

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b227270c8328b065d1a00deab4c0