### PR TITLE
Add Windows startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Dash is an example enterprise web platform demonstrating several features:
    npm run build
    npm start
    ```
+
+### Windows quick start
+Run the PowerShell script to install dependencies, initialise the database, build and launch the backend on a chosen port:
+```powershell
+powershell -ExecutionPolicy Bypass -File .\start-windows.ps1 -port 4000
+```
+The `-port` argument is optional and defaults to `3000`.
+ 
   Browse to `http://localhost:3000` and the web interface should load
   without a separate static file server.
   The frontend now uses `window.location.origin` for API requests so it

--- a/start-windows.ps1
+++ b/start-windows.ps1
@@ -1,0 +1,28 @@
+# Runs the Dash backend on Windows with an optional port parameter.
+# Usage: .\start-windows.ps1 -port 4000
+param(
+    [int]$port = 3000
+)
+
+# Determine the script's directory and move to the backend folder
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location "$scriptDir/backend"
+
+# Install NPM dependencies
+Write-Host "Installing dependencies..."
+npm install
+
+# Run database initialisation
+Write-Host "Running database migrations..."
+npm run db:init
+
+# Compile TypeScript sources
+Write-Host "Building project..."
+npm run build
+
+# Set the PORT environment variable for the Node server
+$env:PORT = $port
+Write-Host "Starting server on port $port..."
+
+# Launch the app
+npm start


### PR DESCRIPTION
## Summary
- add a PowerShell helper script to run the backend on a custom port
- document Windows quick start in the README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885019e72c08328843c50fe8e44158d