### PR TITLE
feat: add Raspberry Pi quick start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,24 @@ Run the PowerShell script to install dependencies, initialise the database, buil
 powershell -ExecutionPolicy Bypass -File .\start-windows.ps1 -port 4000
 ```
 The `-port` argument is optional and defaults to `3000`.
- 
+
   Browse to `http://localhost:3000` and the web interface should load
   without a separate static file server.
   The frontend now uses `window.location.origin` for API requests so it
   automatically points to the host that served the page. If your backend
   runs on a different host or port, update `API_BASE_URL` in
   `frontend/js/app.js` accordingly.
+
+### Raspberry Pi quick start
+The `dash-start-rpi.sh` script sets up and runs the backend on Raspberry Pi or other Linux systems. It installs Node.js 18 if required, installs project dependencies, initialises the database, builds the code and launches the server.
+
+```bash
+chmod +x ./dash-start-rpi.sh
+./dash-start-rpi.sh --port 4000        # development mode on port 4000
+./dash-start-rpi.sh --port 4000 --prod # production mode on port 4000
+```
+
+Omit `--prod` to run in development mode with automatic reloading. The `--port` argument defaults to `3000`.
 
 ### Docker
 

--- a/dash-start-rpi.sh
+++ b/dash-start-rpi.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Quick start script for running the Dash backend on Raspberry Pi or other Linux systems.
+# Installs dependencies, builds the project and launches the server.
+#
+# Usage: ./dash-start-rpi.sh [-p PORT] [--prod]
+#   -p, --port   Port for the server (default: 3000)
+#       --prod   Run in production mode using npm start (default: development via npm run dev)
+#   -h, --help   Show this help message
+
+set -euo pipefail
+
+LOG_FILE="dash_rpi_start.log"
+# Redirect all output to console and log file for debugging
+exec > >(tee -i "$LOG_FILE") 2>&1
+
+PORT=3000
+PROD=false
+
+usage() {
+  echo "Usage: $0 [-p PORT] [--prod]"
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p|--port)
+      PORT="$2"
+      shift 2
+      ;;
+    --prod|--production)
+      PROD=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      echo "Unknown option: $1"
+      usage
+      ;;
+  esac
+done
+
+echo "Dash quick start script"
+echo "========================"
+
+# Check for Node.js and install if missing
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js not found. Installing Node.js 18 (requires sudo)..."
+  curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+  sudo apt-get install -y nodejs
+fi
+
+echo "Using Node.js version $(node -v)"
+
+echo "Selected port: $PORT"
+if $PROD; then
+  echo "Server mode: production"
+else
+  echo "Server mode: development"
+fi
+
+# Move to backend directory relative to script location
+cd "$(dirname "$0")/backend"
+
+echo "Installing npm dependencies..."
+npm install
+
+echo "Initialising database..."
+npm run db:init || echo "Database initialisation failed. Check your DB connection settings."
+
+echo "Building project..."
+npm run build
+
+export PORT="$PORT"
+
+if $PROD; then
+  export NODE_ENV=production
+  echo "Starting Dash backend in production on port $PORT..."
+  npm start
+else
+  echo "Starting Dash backend in development mode on port $PORT..."
+  npm run dev
+fi


### PR DESCRIPTION
## Summary
- add `dash-start-rpi.sh` script for Raspberry Pi/Linux quick start
- document Raspberry Pi usage in README

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68912f0567648328982c01b0c660428c