### PR TITLE
feat: add profile menu and user pages

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -9,11 +9,19 @@
 <body onload="initAdmin()">
   <header>
     <nav>
-      <strong>Dash</strong>
-      <a href="pricing.html">Pricing</a>
-      <a href="dashboard.html">Dashboard</a>
-      <a href="profile.html">Profile</a>
-      <a href="#" onclick="logout()">Logout</a>
+      <a href="dashboard.html"><strong>Dash</strong></a>
+      <!-- Profile menu with navigation options -->
+      <div class="profile">
+        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" onclick="toggleProfileMenu()" />
+        <ul id="profileMenu" class="profile-menu hidden">
+          <li><a href="manage-profiles.html">Manage Profiles</a></li>
+          <li><a href="learning-zone.html">Learning Zone</a></li>
+          <li><a href="profile.html">My Details</a></li>
+          <li><a href="subscription.html">Subscription Details</a></li>
+          <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>
+          <li><a href="#" onclick="logout()">Sign out</a></li>
+        </ul>
+      </div>
     </nav>
   </header>
 

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -29,6 +29,19 @@ header {
   padding: 1rem;
 }
 
+/* Flex layout keeps brand on the left and profile menu on the right */
+header nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+/* Optional container for additional navigation links */
+header nav .nav-links {
+  display: flex;
+  gap: 1rem;
+}
+
 header nav a {
   color: var(--color-light);
   margin-right: 1rem;
@@ -38,6 +51,47 @@ header nav a {
 
 header nav a:hover {
   text-decoration: underline;
+}
+
+/* Profile avatar button and dropdown */
+.profile {
+  position: relative;
+}
+
+.profile-button {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.profile-menu {
+  position: absolute;
+  top: 40px;
+  right: 0;
+  background: var(--color-light);
+  color: var(--color-text);
+  border: 1px solid var(--color-muted);
+  border-radius: 4px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  min-width: 200px;
+  z-index: 1000;
+}
+
+.profile-menu li {
+  padding: 0.5rem 1rem;
+}
+
+.profile-menu li:hover {
+  background: var(--color-background);
+}
+
+.profile-menu a {
+  color: var(--color-text);
+  text-decoration: none;
+  display: block;
 }
 
 /* Landing page hero section */

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -9,11 +9,19 @@
 <body onload="checkAuth()">
   <header>
     <nav>
-      <strong>Dash</strong>
-      <a href="pricing.html">Pricing</a>
-      <a href="profile.html">Profile</a>
-      <a id="adminLink" href="admin.html" class="hidden">Admin</a>
-      <a href="#" onclick="logout()">Logout</a>
+      <a href="dashboard.html"><strong>Dash</strong></a>
+      <!-- Profile menu with navigation options -->
+      <div class="profile">
+        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" onclick="toggleProfileMenu()" />
+        <ul id="profileMenu" class="profile-menu hidden">
+          <li><a href="manage-profiles.html">Manage Profiles</a></li>
+          <li><a href="learning-zone.html">Learning Zone</a></li>
+          <li><a href="profile.html">My Details</a></li>
+          <li><a href="subscription.html">Subscription Details</a></li>
+          <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>
+          <li><a href="#" onclick="logout()">Sign out</a></li>
+        </ul>
+      </div>
     </nav>
   </header>
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -43,6 +43,26 @@ let selectedUser = null; // username of direct message recipient
 let unreadCounts = {};
 let activeTool = 'messages'; // currently selected tool
 
+/** Toggle the visibility of the profile dropdown menu. */
+function toggleProfileMenu() {
+  const menu = document.getElementById('profileMenu');
+  if (menu) {
+    menu.classList.toggle('hidden');
+    console.debug('Profile menu toggled');
+  }
+}
+
+// Hide the profile menu when clicking anywhere outside of it
+document.addEventListener('click', event => {
+  const menu = document.getElementById('profileMenu');
+  const avatar = document.getElementById('navAvatar');
+  if (menu && !menu.classList.contains('hidden')) {
+    if (avatar && !avatar.contains(event.target) && !menu.contains(event.target)) {
+      menu.classList.add('hidden');
+    }
+  }
+});
+
 // Switch between major tools (messaging, CRM, etc.) and update layout
 function selectTool(tool) {
   activeTool = tool;
@@ -398,13 +418,20 @@ function checkAuth() {
   // Store all relevant details for convenience in other functions
   currentUser = { username, token, avatarUrl, role };
 
-  // Display the admin navigation link only when the logged in user is an admin
-  const adminLink = document.getElementById('adminLink');
-  if (adminLink) {
+  // Populate the navbar avatar if present
+  const avatarImg = document.getElementById('navAvatar');
+  if (avatarImg) {
+    avatarImg.src = avatarUrl;
+    avatarImg.alt = `${username} profile`;
+  }
+
+  // Show the "Manage Users" menu option only for admins
+  const manageUsersLink = document.getElementById('manageUsersLink');
+  if (manageUsersLink) {
     if (role === 'admin') {
-      adminLink.classList.remove('hidden');
+      manageUsersLink.classList.remove('hidden');
     } else {
-      adminLink.classList.add('hidden');
+      manageUsersLink.classList.add('hidden');
     }
   }
 

--- a/frontend/learning-zone.html
+++ b/frontend/learning-zone.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>My Details - Dash</title>
+  <title>Learning Zone - Dash</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body onload="checkAuth(); loadProfile()">
+<body onload="checkAuth()">
   <header>
     <nav>
       <a href="dashboard.html"><strong>Dash</strong></a>
@@ -26,21 +26,11 @@
   </header>
 
   <section class="hero">
-    <h1>My Details</h1>
-    <img id="profileImage" class="avatar" alt="profile photo" />
-    <form id="profileForm" class="card" onsubmit="saveProfile(event)">
-      <input id="profileCareer" placeholder="Career history" />
-      <input id="profileEducation" placeholder="Education" />
-      <textarea id="profileStatement" placeholder="Personal statement"></textarea>
-      <button type="submit">Save</button>
-    </form>
-    <form id="photoForm" class="card" onsubmit="return false;">
-      <input id="profilePhoto" type="file" accept="image/*" />
-      <button type="button" onclick="uploadPhoto()">Upload Photo</button>
-    </form>
+    <h1>Learning Zone</h1>
+    <p>Browse tutorials and resources to get the most from Dash.</p>
   </section>
 
   <script src="js/app.js"></script>
-  <script src="js/profile.js"></script>
 </body>
 </html>
+

--- a/frontend/manage-profiles.html
+++ b/frontend/manage-profiles.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>My Details - Dash</title>
+  <title>Manage Profiles - Dash</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body onload="checkAuth(); loadProfile()">
+<body onload="checkAuth()">
   <header>
     <nav>
       <a href="dashboard.html"><strong>Dash</strong></a>
@@ -26,21 +26,11 @@
   </header>
 
   <section class="hero">
-    <h1>My Details</h1>
-    <img id="profileImage" class="avatar" alt="profile photo" />
-    <form id="profileForm" class="card" onsubmit="saveProfile(event)">
-      <input id="profileCareer" placeholder="Career history" />
-      <input id="profileEducation" placeholder="Education" />
-      <textarea id="profileStatement" placeholder="Personal statement"></textarea>
-      <button type="submit">Save</button>
-    </form>
-    <form id="photoForm" class="card" onsubmit="return false;">
-      <input id="profilePhoto" type="file" accept="image/*" />
-      <button type="button" onclick="uploadPhoto()">Upload Photo</button>
-    </form>
+    <h1>Manage Profiles</h1>
+    <p>Control and switch between different user profiles here.</p>
   </section>
 
   <script src="js/app.js"></script>
-  <script src="js/profile.js"></script>
 </body>
 </html>
+

--- a/frontend/subscription.html
+++ b/frontend/subscription.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>My Details - Dash</title>
+  <title>Subscription Details - Dash</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body onload="checkAuth(); loadProfile()">
+<body onload="checkAuth()">
   <header>
     <nav>
       <a href="dashboard.html"><strong>Dash</strong></a>
@@ -26,21 +26,11 @@
   </header>
 
   <section class="hero">
-    <h1>My Details</h1>
-    <img id="profileImage" class="avatar" alt="profile photo" />
-    <form id="profileForm" class="card" onsubmit="saveProfile(event)">
-      <input id="profileCareer" placeholder="Career history" />
-      <input id="profileEducation" placeholder="Education" />
-      <textarea id="profileStatement" placeholder="Personal statement"></textarea>
-      <button type="submit">Save</button>
-    </form>
-    <form id="photoForm" class="card" onsubmit="return false;">
-      <input id="profilePhoto" type="file" accept="image/*" />
-      <button type="button" onclick="uploadPhoto()">Upload Photo</button>
-    </form>
+    <h1>Subscription Details</h1>
+    <p>View and manage your subscription plan and billing information.</p>
   </section>
 
   <script src="js/app.js"></script>
-  <script src="js/profile.js"></script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- add profile avatar dropdown menu with links to profile-related pages
- create placeholder pages for managing profiles, learning zone, and subscription details
- support profile menu toggling and admin-specific user management links

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689207729fe08328845b62d1a5090185