### PR TITLE
Add root package to enable npm install from repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,11 @@ Dash requires Node.js 18+, npm, Docker and access to a MongoDB database.
 ## Project Setup
 1. Clone this repository.
 2. Copy `backend/.env.example` to `backend/.env` and set `DB_URI` to your MongoDB connection string. Optionally set `JWT_SECRET` for token signing.
-3. Install dependencies:
+3. Install dependencies from the repository root (this installs the backend automatically):
+   ```bash
+   npm install
+   ```
+   You can still install directly in the backend directory if preferred:
    ```bash
    cd backend
    npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "dash-root",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dash-root",
+      "version": "1.0.0",
+      "hasInstallScript": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "dash-root",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Root configuration enabling npm install from repository root and delegating operations to the backend service.",
+  "scripts": {
+    "postinstall": "npm install --prefix backend",
+    "start": "npm start --prefix backend",
+    "build": "npm run build --prefix backend",
+    "dev": "npm run dev --prefix backend",
+    "db:init": "npm run db:init --prefix backend",
+    "test": "npm test --prefix backend"
+  }
+}


### PR DESCRIPTION
## Summary
- add root-level package.json with scripts that delegate to backend
- update README to explain installing dependencies from repository root

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894eff2b6948328a9e9e714393a0ea9