### PR TITLE
fix: enable auth forms without inline JS

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -200,6 +200,27 @@ function signup() {
     });
 }
 
+// Attach event listeners for authentication forms after the DOM loads. Using
+// JavaScript listeners keeps inline script out of the HTML, satisfying the
+// strict Content Security Policy while still providing graceful form handling.
+document.addEventListener('DOMContentLoaded', () => {
+  const loginForm = document.getElementById('loginForm');
+  if (loginForm) {
+    loginForm.addEventListener('submit', evt => {
+      evt.preventDefault();
+      login();
+    });
+  }
+
+  const signupForm = document.getElementById('signupForm');
+  if (signupForm) {
+    signupForm.addEventListener('submit', evt => {
+      evt.preventDefault();
+      signup();
+    });
+  }
+});
+
 function sendMessage() {
   const text = document.getElementById('messageInput').value;
 

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -24,7 +24,9 @@
   <!-- Login form -->
   <section class="hero">
     <h1>Login</h1>
-    <form class="card" onsubmit="login(); return false;">
+    <!-- The login form is handled entirely via JavaScript to comply with the
+         Content Security Policy which disallows inline event handlers. -->
+    <form id="loginForm" class="card">
       <input id="username" placeholder="Username" />
       <input id="password" placeholder="Password" type="password" />
       <button type="submit">Login</button>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -23,7 +23,9 @@
   <!-- Signup form -->
   <section class="hero">
     <h1>Create Account</h1>
-    <form class="card" onsubmit="signup(); return false;">
+    <!-- Signup uses JS event listeners so inline handlers are unnecessary
+         and the strict Content Security Policy remains intact. -->
+    <form id="signupForm" class="card">
       <input id="signupUsername" placeholder="Username" />
       <input id="signupPassword" placeholder="Password" type="password" />
       <input id="signupTeamName" placeholder="Team name (new teams)" />


### PR DESCRIPTION
## Summary
- hook login and signup forms with JavaScript event listeners
- remove inline handlers to keep strict Content Security Policy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894f672c0cc8328a08d5779e1dc6c70