### PR TITLE
Ensure navbar profile menu works on every page

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -12,20 +12,20 @@
   <title>Admin Dashboard - Dash</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body onload="initAdmin()">
+<body>
   <header>
     <nav>
       <a href="dashboard.html"><strong>Dash</strong></a>
       <!-- Profile menu with navigation options -->
       <div class="profile">
-        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" onclick="toggleProfileMenu()" />
+        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />
         <ul id="profileMenu" class="profile-menu hidden">
           <li><a href="manage-profiles.html">Manage Profiles</a></li>
           <li><a href="learning-zone.html">Learning Zone</a></li>
           <li><a href="profile.html">My Details</a></li>
           <li><a href="subscription.html">Subscription Details</a></li>
           <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>
-          <li><a href="#" onclick="logout()">Sign out</a></li>
+          <li><a href="#" id="logoutLink">Sign out</a></li>
         </ul>
       </div>
     </nav>

--- a/frontend/js/admin.js
+++ b/frontend/js/admin.js
@@ -21,8 +21,8 @@ function escapeHtml(str) {
 }
 
 function initAdmin() {
-  // Verify the user is logged in and has the correct role
-  checkAuth();
+  // Ensure the user is logged in and has the correct role
+  if (!currentUser) checkAuth();
   if (!currentUser || currentUser.role !== 'admin') {
     window.location.href = 'dashboard.html';
     return;
@@ -214,4 +214,7 @@ function loadAllUsers() {
     });
   });
 }
+
+// Initial setup when the admin page DOM is ready
+document.addEventListener('DOMContentLoaded', initAdmin);
 

--- a/frontend/js/profile.js
+++ b/frontend/js/profile.js
@@ -57,3 +57,12 @@ function uploadPhoto() {
     body: form
   }).then(loadProfile);
 }
+
+// Initialise profile page once DOM is ready
+document.addEventListener('DOMContentLoaded', () => {
+  loadProfile();
+  const form = document.getElementById('profileForm');
+  if (form) form.addEventListener('submit', saveProfile);
+  const uploadBtn = document.getElementById('uploadPhotoBtn');
+  if (uploadBtn) uploadBtn.addEventListener('click', uploadPhoto);
+});

--- a/frontend/learning-zone.html
+++ b/frontend/learning-zone.html
@@ -12,20 +12,20 @@
   <title>Learning Zone - Dash</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body onload="checkAuth()">
+<body>
   <header>
     <nav>
       <a href="dashboard.html"><strong>Dash</strong></a>
       <!-- Profile menu with navigation options -->
       <div class="profile">
-        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" onclick="toggleProfileMenu()" />
+        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />
         <ul id="profileMenu" class="profile-menu hidden">
           <li><a href="manage-profiles.html">Manage Profiles</a></li>
           <li><a href="learning-zone.html">Learning Zone</a></li>
           <li><a href="profile.html">My Details</a></li>
           <li><a href="subscription.html">Subscription Details</a></li>
           <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>
-          <li><a href="#" onclick="logout()">Sign out</a></li>
+          <li><a href="#" id="logoutLink">Sign out</a></li>
         </ul>
       </div>
     </nav>

--- a/frontend/manage-profiles.html
+++ b/frontend/manage-profiles.html
@@ -12,20 +12,20 @@
   <title>Manage Profiles - Dash</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body onload="checkAuth()">
+<body>
   <header>
     <nav>
       <a href="dashboard.html"><strong>Dash</strong></a>
       <!-- Profile menu with navigation options -->
       <div class="profile">
-        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" onclick="toggleProfileMenu()" />
+        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />
         <ul id="profileMenu" class="profile-menu hidden">
           <li><a href="manage-profiles.html">Manage Profiles</a></li>
           <li><a href="learning-zone.html">Learning Zone</a></li>
           <li><a href="profile.html">My Details</a></li>
           <li><a href="subscription.html">Subscription Details</a></li>
           <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>
-          <li><a href="#" onclick="logout()">Sign out</a></li>
+          <li><a href="#" id="logoutLink">Sign out</a></li>
         </ul>
       </div>
     </nav>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -12,20 +12,20 @@
   <title>My Details - Dash</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body onload="checkAuth(); loadProfile()">
+<body>
   <header>
     <nav>
       <a href="dashboard.html"><strong>Dash</strong></a>
       <!-- Profile menu with navigation options -->
       <div class="profile">
-        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" onclick="toggleProfileMenu()" />
+        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />
         <ul id="profileMenu" class="profile-menu hidden">
           <li><a href="manage-profiles.html">Manage Profiles</a></li>
           <li><a href="learning-zone.html">Learning Zone</a></li>
           <li><a href="profile.html">My Details</a></li>
           <li><a href="subscription.html">Subscription Details</a></li>
           <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>
-          <li><a href="#" onclick="logout()">Sign out</a></li>
+          <li><a href="#" id="logoutLink">Sign out</a></li>
         </ul>
       </div>
     </nav>
@@ -34,15 +34,15 @@
   <section class="hero">
     <h1>My Details</h1>
     <img id="profileImage" class="avatar" alt="profile photo" />
-    <form id="profileForm" class="card" onsubmit="saveProfile(event)">
+    <form id="profileForm" class="card">
       <input id="profileCareer" placeholder="Career history" />
       <input id="profileEducation" placeholder="Education" />
       <textarea id="profileStatement" placeholder="Personal statement"></textarea>
       <button type="submit">Save</button>
     </form>
-    <form id="photoForm" class="card" onsubmit="return false;">
+    <form id="photoForm" class="card">
       <input id="profilePhoto" type="file" accept="image/*" />
-      <button type="button" onclick="uploadPhoto()">Upload Photo</button>
+      <button type="button" id="uploadPhotoBtn">Upload Photo</button>
     </form>
   </section>
 

--- a/frontend/subscription.html
+++ b/frontend/subscription.html
@@ -12,20 +12,20 @@
   <title>Subscription Details - Dash</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body onload="checkAuth()">
+<body>
   <header>
     <nav>
       <a href="dashboard.html"><strong>Dash</strong></a>
       <!-- Profile menu with navigation options -->
       <div class="profile">
-        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" onclick="toggleProfileMenu()" />
+        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />
         <ul id="profileMenu" class="profile-menu hidden">
           <li><a href="manage-profiles.html">Manage Profiles</a></li>
           <li><a href="learning-zone.html">Learning Zone</a></li>
           <li><a href="profile.html">My Details</a></li>
           <li><a href="subscription.html">Subscription Details</a></li>
           <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>
-          <li><a href="#" onclick="logout()">Sign out</a></li>
+          <li><a href="#" id="logoutLink">Sign out</a></li>
         </ul>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- remove inline profile menu and logout handlers from static pages
- initialise authentication and profile dropdown globally in app.js
- load profile and admin pages via script-based DOM events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68970b10b4188328ad2a64a6dd20269f