### PR TITLE
feat: add profile visibility controls

### DIFF
--- a/backend/src/models/profile.ts
+++ b/backend/src/models/profile.ts
@@ -5,20 +5,31 @@ import { Schema, model, Document, Types } from 'mongoose';
  * document so additional details can be added without altering the
  * authentication model. Each user has at most one profile.
  */
+/** Visibility levels for profile fields */
+export type Visibility = 'world' | 'platform' | 'team';
+
 export interface IProfile extends Document {
   user: Types.ObjectId;
-  photo?: string;      // URL path to the uploaded profile image
-  career?: string;     // brief career history
-  education?: string;  // education summary
-  statement?: string;  // personal statement
+  photo?: string;              // URL path to the uploaded profile image
+  photoVisibility: Visibility; // who can see the photo
+  career?: string;             // brief career history
+  careerVisibility: Visibility;
+  education?: string;          // education summary
+  educationVisibility: Visibility;
+  statement?: string;          // personal statement
+  statementVisibility: Visibility;
 }
 
 const ProfileSchema = new Schema<IProfile>({
   user: { type: Schema.Types.ObjectId, ref: 'User', unique: true, required: true },
   photo: String,
+  photoVisibility: { type: String, enum: ['world', 'platform', 'team'], default: 'platform' },
   career: String,
+  careerVisibility: { type: String, enum: ['world', 'platform', 'team'], default: 'platform' },
   education: String,
-  statement: String
+  educationVisibility: { type: String, enum: ['world', 'platform', 'team'], default: 'platform' },
+  statement: String,
+  statementVisibility: { type: String, enum: ['world', 'platform', 'team'], default: 'platform' }
 });
 
 export const Profile = model<IProfile>('Profile', ProfileSchema);

--- a/backend/test/profile.test.ts
+++ b/backend/test/profile.test.ts
@@ -12,11 +12,15 @@ process.env.JWT_SECRET = 'testsecret';
 import { app } from '../src/index';
 import { connectDB } from '../src/db';
 import { User } from '../src/models/user';
+import { Team } from '../src/models/team';
 import fs from 'fs';
 import path from 'path';
 
 let mongo: MongoMemoryServer;
-let userToken: string;
+let userAToken: string;
+let userBToken: string;
+let userCToken: string;
+let userAId: string;
 
 beforeAll(async () => {
   process.env.JWT_SECRET = 'testsecret';
@@ -25,10 +29,24 @@ beforeAll(async () => {
   await connectDB();
 
   const hashed = await bcrypt.hash('secret', 10);
-  const user = new User({ username: 'user@test.com', password: hashed, role: 'user' });
-  await user.save();
-  userToken = jwt.sign(
-    { id: user.id, username: user.username, role: user.role },
+  const team1 = await new Team({ name: 'Team1' }).save();
+  const team2 = await new Team({ name: 'Team2' }).save();
+  const userA = await new User({ username: 'userA@test.com', password: hashed, role: 'user', team: team1.id }).save();
+  const userB = await new User({ username: 'userB@test.com', password: hashed, role: 'user', team: team1.id }).save();
+  const userC = await new User({ username: 'userC@test.com', password: hashed, role: 'user', team: team2.id }).save();
+  userAId = userA.id;
+  userAToken = jwt.sign(
+    { id: userA.id, username: userA.username, role: userA.role, team: team1.id },
+    process.env.JWT_SECRET!,
+    { expiresIn: '1h' }
+  );
+  userBToken = jwt.sign(
+    { id: userB.id, username: userB.username, role: userB.role, team: team1.id },
+    process.env.JWT_SECRET!,
+    { expiresIn: '1h' }
+  );
+  userCToken = jwt.sign(
+    { id: userC.id, username: userC.username, role: userC.role, team: team2.id },
     process.env.JWT_SECRET!,
     { expiresIn: '1h' }
   );
@@ -43,25 +61,56 @@ afterAll(async () => {
 test('profile lifecycle', async () => {
   const update = await request(app)
     .post('/api/profile/me')
-    .set('Authorization', `Bearer ${userToken}`)
-    .send({ career: 'Developer', education: 'CS Degree', statement: 'Hello' });
+    .set('Authorization', `Bearer ${userAToken}`)
+    .send({
+      career: 'Developer',
+      education: 'CS Degree',
+      statement: 'Hello',
+      careerVisibility: 'world',
+      educationVisibility: 'platform',
+      statementVisibility: 'team',
+      photoVisibility: 'platform'
+    });
   expect(update.status).toBe(200);
-  expect(update.body.career).toBe('Developer');
+  expect(update.body.careerVisibility).toBe('world');
 
   // create a temporary image file to upload
   const tmp = path.join(__dirname, 'temp.png');
   fs.writeFileSync(tmp, 'data');
   const photoRes = await request(app)
     .post('/api/profile/me/photo')
-    .set('Authorization', `Bearer ${userToken}`)
+    .set('Authorization', `Bearer ${userAToken}`)
+    .field('visibility', 'world')
     .attach('photo', tmp);
   expect(photoRes.status).toBe(200);
   expect(photoRes.body.photo).toContain('/uploads/');
+  expect(photoRes.body.photoVisibility).toBe('world');
   fs.unlinkSync(tmp);
 
   const get = await request(app)
     .get('/api/profile/me')
-    .set('Authorization', `Bearer ${userToken}`);
+    .set('Authorization', `Bearer ${userAToken}`);
   expect(get.body.education).toBe('CS Degree');
   expect(get.body.photo).toEqual(photoRes.body.photo);
+});
+
+/** Ensure visibility settings control access to fields */
+test('visibility filtering', async () => {
+  // No token -> only world-visible fields
+  const unauth = await request(app).get(`/api/profile/${userAId}`);
+  expect(unauth.body.career).toBe('Developer');
+  expect(unauth.body.education).toBeUndefined();
+
+  // Same team -> team-visible fields returned
+  const sameTeam = await request(app)
+    .get(`/api/profile/${userAId}`)
+    .set('Authorization', `Bearer ${userBToken}`);
+  expect(sameTeam.body.statement).toBe('Hello');
+
+  // Different team -> team fields hidden but platform fields shown
+  const diffTeam = await request(app)
+    .get(`/api/profile/${userAId}`)
+    .set('Authorization', `Bearer ${userCToken}`);
+  expect(diffTeam.body.education).toBe('CS Degree');
+  expect(diffTeam.body.statement).toBeUndefined();
 });

--- a/frontend/js/profile.js
+++ b/frontend/js/profile.js
@@ -22,6 +22,15 @@ function loadProfile() {
       document.getElementById('profileCareer').value = p.career || '';
       document.getElementById('profileEducation').value = p.education || '';
       document.getElementById('profileStatement').value = p.statement || '';
+      // Set visibility radio buttons based on stored preferences
+      const setVis = (name, value) => {
+        const radio = document.querySelector(`input[name="${name}"][value="${value || 'platform'}"]`);
+        if (radio) radio.checked = true;
+      };
+      setVis('careerVisibility', p.careerVisibility);
+      setVis('educationVisibility', p.educationVisibility);
+      setVis('statementVisibility', p.statementVisibility);
+      setVis('photoVisibility', p.photoVisibility);
       if (p.photo) {
         document.getElementById('profileImage').src = p.photo;
       }
@@ -40,7 +49,11 @@ function saveProfile(e) {
     body: JSON.stringify({
       career: document.getElementById('profileCareer').value,
       education: document.getElementById('profileEducation').value,
-      statement: document.getElementById('profileStatement').value
+      statement: document.getElementById('profileStatement').value,
+      careerVisibility: document.querySelector('input[name="careerVisibility"]:checked').value,
+      educationVisibility: document.querySelector('input[name="educationVisibility"]:checked').value,
+      statementVisibility: document.querySelector('input[name="statementVisibility"]:checked').value,
+      photoVisibility: document.querySelector('input[name="photoVisibility"]:checked').value
     })
   }).then(loadProfile);
 }
@@ -49,8 +62,9 @@ function uploadPhoto() {
   const token = sessionStorage.getItem('token');
   const file = document.getElementById('profilePhoto').files[0];
   if (!file) return;
-  const form = new FormData();
-  form.append('photo', file);
+    const form = new FormData();
+    form.append('photo', file);
+    form.append('visibility', document.querySelector('input[name="photoVisibility"]:checked').value);
   fetch(`${API_BASE_URL}/api/profile/me/photo`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` },

--- a/frontend/js/view-profile.js
+++ b/frontend/js/view-profile.js
@@ -1,0 +1,47 @@
+/**
+ * View profile page logic
+ * -----------------------
+ * Fetches another user's profile based on the `id` query parameter and displays
+ * the fields permitted by the profile's visibility settings. Tokens are
+ * included if available to access platform or team restricted data.
+ */
+const API_BASE_URL = window.location.origin;
+
+function getQueryId() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('id');
+}
+
+function loadProfile() {
+  const id = getQueryId();
+  if (!id) {
+    document.getElementById('profileDetails').innerText = 'No user specified.';
+    return;
+  }
+  const token = sessionStorage.getItem('token');
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  fetch(`${API_BASE_URL}/api/profile/${id}`, { headers })
+    .then(r => r.json())
+    .then(p => {
+      const details = document.getElementById('profileDetails');
+      if (!p || p.message) {
+        details.textContent = 'Profile not available.';
+        return;
+      }
+      if (p.photo) document.getElementById('profileImage').src = p.photo;
+      details.textContent = '';
+      const addField = (label, value) => {
+        const pEl = document.createElement('p');
+        const strong = document.createElement('strong');
+        strong.textContent = label;
+        pEl.appendChild(strong);
+        pEl.append(` ${value}`);
+        details.appendChild(pEl);
+      };
+      if (p.career) addField('Career:', p.career);
+      if (p.education) addField('Education:', p.education);
+      if (p.statement) addField('Statement:', p.statement);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', loadProfile);

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -35,9 +35,41 @@
     <h1>My Details</h1>
     <img id="profileImage" class="avatar" alt="profile photo" />
     <form id="profileForm" class="card">
-      <input id="profileCareer" placeholder="Career history" />
-      <input id="profileEducation" placeholder="Education" />
-      <textarea id="profileStatement" placeholder="Personal statement"></textarea>
+      <div>
+        <input id="profileCareer" placeholder="Career history" />
+        <div class="visibility">
+          <span>Visibility:</span>
+          <label><input type="radio" name="careerVisibility" value="world">World</label>
+          <label><input type="radio" name="careerVisibility" value="platform" checked>Platform</label>
+          <label><input type="radio" name="careerVisibility" value="team">Team</label>
+        </div>
+      </div>
+      <div>
+        <input id="profileEducation" placeholder="Education" />
+        <div class="visibility">
+          <span>Visibility:</span>
+          <label><input type="radio" name="educationVisibility" value="world">World</label>
+          <label><input type="radio" name="educationVisibility" value="platform" checked>Platform</label>
+          <label><input type="radio" name="educationVisibility" value="team">Team</label>
+        </div>
+      </div>
+      <div>
+        <textarea id="profileStatement" placeholder="Personal statement"></textarea>
+        <div class="visibility">
+          <span>Visibility:</span>
+          <label><input type="radio" name="statementVisibility" value="world">World</label>
+          <label><input type="radio" name="statementVisibility" value="platform" checked>Platform</label>
+          <label><input type="radio" name="statementVisibility" value="team">Team</label>
+        </div>
+      </div>
+      <div>
+        <span>Photo visibility:</span>
+        <div class="visibility">
+          <label><input type="radio" name="photoVisibility" value="world">World</label>
+          <label><input type="radio" name="photoVisibility" value="platform" checked>Platform</label>
+          <label><input type="radio" name="photoVisibility" value="team">Team</label>
+        </div>
+      </div>
       <button type="submit">Save</button>
     </form>
     <form id="photoForm" class="card">

--- a/frontend/view-profile.html
+++ b/frontend/view-profile.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!--
+    Mini readme: View Profile page
+    Displays another user's profile based on the `id` query parameter. Uses
+    local assets and a strict Content Security Policy for security.
+  -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
+  <title>User Profile - Dash</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="dashboard.html"><strong>Dash</strong></a>
+      <!-- Profile menu with navigation options -->
+      <div class="profile">
+        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />
+        <ul id="profileMenu" class="profile-menu hidden">
+          <li><a href="manage-profiles.html">Manage Profiles</a></li>
+          <li><a href="learning-zone.html">Learning Zone</a></li>
+          <li><a href="profile.html">My Details</a></li>
+          <li><a href="subscription.html">Subscription Details</a></li>
+          <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>
+          <li><a href="#" id="logoutLink">Sign out</a></li>
+        </ul>
+      </div>
+    </nav>
+  </header>
+
+  <section class="hero">
+    <h1>User Profile</h1>
+    <img id="profileImage" class="avatar" alt="profile photo" />
+    <div id="profileDetails" class="card"></div>
+  </section>
+
+  <script src="js/app.js"></script>
+  <script src="js/view-profile.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add optional authentication middleware for public endpoints
- support per-field visibility in user profiles
- expose read-only profile viewer page for other users

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68970f9e15d88328922623dd57e87b28