### PR TITLE
Fix profile layout and photo loading

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -99,8 +99,9 @@ header nav a:hover {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  height: calc(100vh - 70px);
+  justify-content: flex-start;
+  min-height: calc(100vh - 70px);
+  padding: 2rem 1rem;
   text-align: center;
   color: var(--color-light);
   background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
@@ -111,7 +112,10 @@ header nav a:hover {
 }
 
 .hero .card {
-  width: 300px;
+  width: 100%;
+  max-width: 500px;
+  color: var(--color-text);
+  text-align: left;
 }
 
 /* Layout for the dashboard with two sidebars similar to Slack/Teams */
@@ -330,5 +334,19 @@ button:hover {
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0,0,0,0.1);
   margin-bottom: 1rem;
+  color: var(--color-text);
+}
+
+/* Arrange radio button visibility controls horizontally with spacing */
+.visibility {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.visibility label {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 


### PR DESCRIPTION
## Summary
- ensure profile cards use readable text and include styles for radio button groups
- rework hero layout to prevent white-on-white text and support responsive width
- fetch profile photos with authentication and log errors during save/upload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689737332a5083289b3754e657380c82