### PR TITLE
Fix profile upload and add profile view link

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -22,6 +22,7 @@
         <ul id="profileMenu" class="profile-menu hidden">
           <li><a href="manage-profiles.html">Manage Profiles</a></li>
           <li><a href="learning-zone.html">Learning Zone</a></li>
+          <li><a href="view-profile.html?id=me">View Profile Page</a></li>
           <li><a href="profile.html">My Details</a></li>
           <li><a href="subscription.html">Subscription Details</a></li>
           <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -23,6 +23,7 @@
         <ul id="profileMenu" class="profile-menu hidden">
           <li><a href="manage-profiles.html">Manage Profiles</a></li>
           <li><a href="learning-zone.html">Learning Zone</a></li>
+          <li><a href="view-profile.html?id=me">View Profile Page</a></li>
           <li><a href="profile.html">My Details</a></li>
           <li><a href="subscription.html">Subscription Details</a></li>
           <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>

--- a/frontend/js/profile.js
+++ b/frontend/js/profile.js
@@ -4,8 +4,8 @@
  * Loads and saves the current user's profile details. Tokens are read from
  * sessionStorage for shorter-lived exposure in the browser. Profile photos are
  * retrieved via an authenticated request so they can be stored behind a
- * protected route on the server. Photo uploads provide immediate on-screen
- * status updates to keep the user informed.
+ * protected route on the server. Save operations and photo uploads provide
+ * immediate on-screen status updates to keep the user informed.
 */
 const API_BASE_URL = window.location.origin;
 
@@ -50,6 +50,13 @@ function loadProfile() {
 function saveProfile(e) {
   e.preventDefault();
   const token = sessionStorage.getItem('token');
+  const statusEl = document.getElementById('profileSaveStatus');
+  const saveBtn = document.getElementById('saveProfileBtn');
+
+  if (statusEl) statusEl.textContent = 'Saving profile...';
+  if (saveBtn) saveBtn.disabled = true;
+  console.log('Saving profile details');
+
   fetch(`${API_BASE_URL}/api/profile/me`, {
     method: 'POST',
     headers: {
@@ -66,8 +73,20 @@ function saveProfile(e) {
       photoVisibility: document.querySelector('input[name="photoVisibility"]:checked').value
     })
   })
-    .then(loadProfile)
-    .catch(err => console.error('Failed to save profile', err));
+    .then(r => {
+      if (!r.ok) throw new Error('Save failed');
+      console.log('Profile save complete');
+      if (statusEl) statusEl.textContent = 'Profile saved';
+      loadProfile();
+    })
+    .catch(err => {
+      console.error('Failed to save profile', err);
+      if (statusEl) statusEl.textContent = 'Save failed';
+    })
+    .finally(() => {
+      if (saveBtn) saveBtn.disabled = false;
+      if (statusEl) setTimeout(() => (statusEl.textContent = ''), 3000);
+    });
 }
 
 function uploadPhoto() {

--- a/frontend/js/view-profile.js
+++ b/frontend/js/view-profile.js
@@ -1,10 +1,11 @@
 /**
  * View profile page logic
  * -----------------------
- * Fetches another user's profile based on the `id` query parameter and displays
- * the fields permitted by the profile's visibility settings. Tokens are
- * included if available to access platform or team restricted data.
- */
+ * Fetches a user's profile based on the `id` query parameter and displays the
+ * fields permitted by the profile's visibility settings. If `id` is omitted or
+ * set to `me` the current user's details are shown. Tokens are included if
+ * available to access platform or team restricted data.
+*/
 const API_BASE_URL = window.location.origin;
 
 function getQueryId() {
@@ -13,23 +14,31 @@ function getQueryId() {
 }
 
 function loadProfile() {
-  const id = getQueryId();
-  if (!id) {
-    document.getElementById('profileDetails').innerText = 'No user specified.';
+  const id = getQueryId() || 'me';
+  const token = sessionStorage.getItem('token');
+  const details = document.getElementById('profileDetails');
+  if (id === 'me' && !token) {
+    details.textContent = 'No user specified.';
     return;
   }
-  const token = sessionStorage.getItem('token');
   const headers = token ? { Authorization: `Bearer ${token}` } : {};
-  fetch(`${API_BASE_URL}/api/profile/${id}`, { headers })
+  const url = id === 'me' ? `${API_BASE_URL}/api/profile/me` : `${API_BASE_URL}/api/profile/${id}`;
+  fetch(url, { headers })
     .then(r => r.json())
     .then(p => {
-      const details = document.getElementById('profileDetails');
       if (!p || p.message) {
         details.textContent = 'Profile not available.';
         return;
       }
-      if (p.photo) document.getElementById('profileImage').src = p.photo;
       details.textContent = '';
+      if (p.photo) {
+        fetch(`${API_BASE_URL}${p.photo}`, { headers })
+          .then(r => (r.ok ? r.blob() : Promise.reject('Failed to load photo')))
+          .then(b => {
+            document.getElementById('profileImage').src = URL.createObjectURL(b);
+          })
+          .catch(err => console.error(err));
+      }
       const addField = (label, value) => {
         const pEl = document.createElement('p');
         const strong = document.createElement('strong');

--- a/frontend/learning-zone.html
+++ b/frontend/learning-zone.html
@@ -22,6 +22,7 @@
         <ul id="profileMenu" class="profile-menu hidden">
           <li><a href="manage-profiles.html">Manage Profiles</a></li>
           <li><a href="learning-zone.html">Learning Zone</a></li>
+          <li><a href="view-profile.html?id=me">View Profile Page</a></li>
           <li><a href="profile.html">My Details</a></li>
           <li><a href="subscription.html">Subscription Details</a></li>
           <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>

--- a/frontend/manage-profiles.html
+++ b/frontend/manage-profiles.html
@@ -22,6 +22,7 @@
         <ul id="profileMenu" class="profile-menu hidden">
           <li><a href="manage-profiles.html">Manage Profiles</a></li>
           <li><a href="learning-zone.html">Learning Zone</a></li>
+          <li><a href="view-profile.html?id=me">View Profile Page</a></li>
           <li><a href="profile.html">My Details</a></li>
           <li><a href="subscription.html">Subscription Details</a></li>
           <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -4,8 +4,8 @@
   <!--
     Mini readme: Profile page
     Displays and edits personal profile information with on-screen feedback for
-    photo uploads. Loads required assets from local files only and applies a
-    strict Content Security Policy.
+    saving changes and photo uploads. Loads required assets from local files
+    only and applies a strict Content Security Policy.
   -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -23,6 +23,7 @@
         <ul id="profileMenu" class="profile-menu hidden">
           <li><a href="manage-profiles.html">Manage Profiles</a></li>
           <li><a href="learning-zone.html">Learning Zone</a></li>
+          <li><a href="view-profile.html?id=me">View Profile Page</a></li>
           <li><a href="profile.html">My Details</a></li>
           <li><a href="subscription.html">Subscription Details</a></li>
           <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>
@@ -71,7 +72,8 @@
           <label><input type="radio" name="photoVisibility" value="team">Team</label>
         </div>
       </div>
-      <button type="submit">Save</button>
+      <button type="submit" id="saveProfileBtn">Save</button>
+      <span id="profileSaveStatus" class="status" aria-live="polite"></span>
     </form>
     <form id="photoForm" class="card">
       <input id="profilePhoto" type="file" accept="image/*" />

--- a/frontend/subscription.html
+++ b/frontend/subscription.html
@@ -22,6 +22,7 @@
         <ul id="profileMenu" class="profile-menu hidden">
           <li><a href="manage-profiles.html">Manage Profiles</a></li>
           <li><a href="learning-zone.html">Learning Zone</a></li>
+          <li><a href="view-profile.html?id=me">View Profile Page</a></li>
           <li><a href="profile.html">My Details</a></li>
           <li><a href="subscription.html">Subscription Details</a></li>
           <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>

--- a/frontend/view-profile.html
+++ b/frontend/view-profile.html
@@ -3,8 +3,9 @@
 <head>
   <!--
     Mini readme: View Profile page
-    Displays another user's profile based on the `id` query parameter. Uses
-    local assets and a strict Content Security Policy for security.
+    Displays a user's profile based on the `id` query parameter, or the current
+    user when omitted. Uses local assets and a strict Content Security Policy
+    for security.
   -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -22,6 +23,7 @@
         <ul id="profileMenu" class="profile-menu hidden">
           <li><a href="manage-profiles.html">Manage Profiles</a></li>
           <li><a href="learning-zone.html">Learning Zone</a></li>
+          <li><a href="view-profile.html?id=me">View Profile Page</a></li>
           <li><a href="profile.html">My Details</a></li>
           <li><a href="subscription.html">Subscription Details</a></li>
           <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>


### PR DESCRIPTION
## Summary
- Provide status messages and button disabling when saving profile details or uploading a photo
- Add "View Profile Page" link to profile dropdown menus
- Allow view-profile page to display the current user and fetch protected photos

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68974b426c248328b919a76ace85303d