### PR TITLE
feat: add branding favicon and wordmark

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -10,12 +10,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Admin Dashboard - Dash</title>
+  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <header>
     <nav>
-      <a href="dashboard.html"><strong>Dash</strong></a>
+      <a href="dashboard.html" class="wordmark">Dash</a>
       <!-- Profile menu with navigation options -->
       <div class="profile">
         <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -84,6 +84,22 @@ header nav a:hover {
   text-decoration: underline;
 }
 
+/* Wordmark branding: bold italic Rockwell with a leading triple bar */
+header nav .wordmark {
+  font-family: "Rockwell", serif;
+  font-weight: 700;
+  font-style: italic;
+  display: inline-flex;
+  align-items: center;
+}
+
+header nav .wordmark::before {
+  content: "\2261"; /* Unicode for ≡ */
+  font-family: "Cambria Math", serif;
+  font-style: oblique;
+  margin-right: 0.25rem;
+}
+
 /* Profile avatar button and dropdown */
 .profile {
   position: relative;

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -11,12 +11,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Dashboard - Dash</title>
+  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <header>
     <nav>
-      <a href="dashboard.html"><strong>Dash</strong></a>
+      <a href="dashboard.html" class="wordmark">Dash</a>
       <!-- Profile menu with navigation options -->
       <div class="profile">
         <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />

--- a/frontend/img/dash-logo.svg
+++ b/frontend/img/dash-logo.svg
@@ -1,0 +1,9 @@
+<!--
+  Mini readme: Dash logo favicon
+  Provides the brand wordmark with a leading triple bar symbol. Rendered as
+  SVG so it scales cleanly for the browser tab icon.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 40">
+  <text x="0" y="30" font-family="Cambria Math, 'Cambria Math_MSFontService', serif" font-style="oblique" font-weight="700" font-size="30">≡</text>
+  <text x="30" y="30" font-family="Rockwell, 'Rockwell_MSFontService', serif" font-style="italic" font-weight="700" font-size="30">Dash</text>
+</svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,13 +10,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Dash</title>
+  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <!-- Simple brand header for consistent styling -->
   <header>
     <nav>
-      <strong>Dash</strong>
+      <a href="index.html" class="wordmark">Dash</a>
       <a href="pricing.html">Pricing</a>
     </nav>
   </header>

--- a/frontend/learning-zone.html
+++ b/frontend/learning-zone.html
@@ -10,12 +10,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Learning Zone - Dash</title>
+  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <header>
     <nav>
-      <a href="dashboard.html"><strong>Dash</strong></a>
+      <a href="dashboard.html" class="wordmark">Dash</a>
       <!-- Profile menu with navigation options -->
       <div class="profile">
         <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -11,12 +11,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Login - Dash</title>
+  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <header>
     <nav>
-      <strong>Dash</strong>
+      <a href="index.html" class="wordmark">Dash</a>
       <a href="pricing.html">Pricing</a>
     </nav>
   </header>

--- a/frontend/manage-profiles.html
+++ b/frontend/manage-profiles.html
@@ -10,12 +10,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Manage Profiles - Dash</title>
+  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <header>
     <nav>
-      <a href="dashboard.html"><strong>Dash</strong></a>
+      <a href="dashboard.html" class="wordmark">Dash</a>
       <!-- Profile menu with navigation options -->
       <div class="profile">
         <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -10,12 +10,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Pricing - Dash</title>
+  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <header>
     <nav>
-      <strong>Dash</strong>
+      <a href="index.html" class="wordmark">Dash</a>
       <a href="login.html">Login</a>
       <a href="signup.html">Sign Up</a>
     </nav>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -11,12 +11,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>My Details - Dash</title>
+  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <header>
     <nav>
-      <a href="dashboard.html"><strong>Dash</strong></a>
+      <a href="dashboard.html" class="wordmark">Dash</a>
       <!-- Profile menu with navigation options -->
       <div class="profile">
         <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -10,12 +10,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Sign Up - Dash</title>
+  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <header>
     <nav>
-      <strong>Dash</strong>
+      <a href="index.html" class="wordmark">Dash</a>
       <a href="pricing.html">Pricing</a>
     </nav>
   </header>

--- a/frontend/subscription.html
+++ b/frontend/subscription.html
@@ -10,12 +10,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Subscription Details - Dash</title>
+  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <header>
     <nav>
-      <a href="dashboard.html"><strong>Dash</strong></a>
+      <a href="dashboard.html" class="wordmark">Dash</a>
       <!-- Profile menu with navigation options -->
       <div class="profile">
         <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />

--- a/frontend/view-profile.html
+++ b/frontend/view-profile.html
@@ -11,12 +11,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>User Profile - Dash</title>
+  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <header>
     <nav>
-      <a href="dashboard.html"><strong>Dash</strong></a>
+      <a href="dashboard.html" class="wordmark">Dash</a>
       <!-- Profile menu with navigation options -->
       <div class="profile">
         <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />


### PR DESCRIPTION
## Summary
- add SVG favicon containing the Dash logo
- style and display a Rockwell-based Dash wordmark in the navigation bar
- include favicon link across all frontend pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f67ddbd708328b73a028403726b9f