### PR TITLE
refactor: reference users in timesheet and leave models

### DIFF
--- a/backend/src/models/leave.ts
+++ b/backend/src/models/leave.ts
@@ -1,19 +1,26 @@
-import { Schema, model, Document } from 'mongoose';
+import { Schema, model, Document, Types } from 'mongoose';
 
 /**
- * Leave request record.
+ * Leave Model
+ * -----------
+ * Represents a request by a user to take leave within a specific date range.
+ *
+ * Structure
+ *  - `ILeave` interface for TypeScript consumers.
+ *  - `LeaveSchema` defining the MongoDB schema.
+ *  - `Leave` Mongoose model used for database operations.
  */
 export interface ILeave extends Document {
-  userId: number;
-  startDate: string;
-  endDate: string;
-  status: 'pending' | 'approved' | 'rejected';
+  user: Types.ObjectId;          // reference to the requesting user
+  startDate: Date;               // first day of leave
+  endDate: Date;                 // last day of leave
+  status: 'pending' | 'approved' | 'rejected'; // approval status
 }
 
 const LeaveSchema = new Schema<ILeave>({
-  userId: { type: Number, required: true },
-  startDate: { type: String, required: true },
-  endDate: { type: String, required: true },
+  user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  startDate: { type: Date, required: true },
+  endDate: { type: Date, required: true },
   status: {
     type: String,
     enum: ['pending', 'approved', 'rejected'],

--- a/backend/src/models/timesheet.ts
+++ b/backend/src/models/timesheet.ts
@@ -1,18 +1,25 @@
-import { Schema, model, Document } from 'mongoose';
+import { Schema, model, Document, Types } from 'mongoose';
 
 /**
- * Hours logged by a user for a specific date.
+ * Timesheet Model
+ * ----------------
+ * Stores the number of hours a user logs for a specific calendar day.
+ *
+ * Structure
+ *  - `ITimesheet` interface describing the TypeScript shape.
+ *  - `TimesheetSchema` defining the MongoDB document schema.
+ *  - `Timesheet` Mongoose model for database interactions.
  */
 export interface ITimesheet extends Document {
-  userId: number;
-  hours: number;
-  date: string;
+  user: Types.ObjectId; // reference to the user who logged the hours
+  hours: number;        // number of hours worked
+  date: Date;           // date for which the hours are recorded
 }
 
 const TimesheetSchema = new Schema<ITimesheet>({
-  userId: { type: Number, required: true },
+  user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
   hours: { type: Number, required: true },
-  date: { type: String, required: true }
+  date: { type: Date, required: true }
 });
 
 export const Timesheet = model<ITimesheet>('Timesheet', TimesheetSchema);


### PR DESCRIPTION
## Summary
- reference `User` documents instead of numeric `userId` in timesheet and leave schemas
- store `date`, `startDate`, and `endDate` as `Date` objects
- document models with detailed headers and inline comments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fa5fbe4348328a2ffc50a7e4fa07a