### PR TITLE
docs: document timesheet and leave modules

### DIFF
--- a/backend/src/models/leave.ts
+++ b/backend/src/models/leave.ts
@@ -1,15 +1,27 @@
-import { Schema, model, Document, Types } from 'mongoose';
-
 /**
- * Leave Model
- * -----------
- * Represents a request by a user to take leave within a specific date range.
+ * @file Leave model.
+ *
+ * Purpose
+ * -------
+ * Captures a user's request to take leave over a defined date range.
  *
  * Structure
- *  - `ILeave` interface for TypeScript consumers.
- *  - `LeaveSchema` defining the MongoDB schema.
- *  - `Leave` Mongoose model used for database operations.
+ * ---------
+ * - `ILeave` interface: TypeScript shape of a leave document.
+ * - `LeaveSchema`: Mongoose schema mapping model fields to MongoDB.
+ * - `Leave` model: Exported Mongoose model for interacting with the collection.
+ *
+ * Key Interactions
+ * ----------------
+ * - Used by `routes/leaves.ts` for CRUD operations on leave requests.
+ * - Requires an active Mongoose connection established in `db.ts`.
+ *
+ * Assumptions
+ * -----------
+ * - `DB_URI` environment variable points to the MongoDB instance.
+ * - A database connection is created prior to importing this module.
  */
+import { Schema, model, Document, Types } from 'mongoose';
 export interface ILeave extends Document {
   user: Types.ObjectId;          // reference to the requesting user
   startDate: Date;               // first day of leave

--- a/backend/src/models/timesheet.ts
+++ b/backend/src/models/timesheet.ts
@@ -1,15 +1,27 @@
-import { Schema, model, Document, Types } from 'mongoose';
-
 /**
- * Timesheet Model
- * ----------------
- * Stores the number of hours a user logs for a specific calendar day.
+ * @file Timesheet model.
+ *
+ * Purpose
+ * -------
+ * Defines how a user's daily logged hours are stored in MongoDB.
  *
  * Structure
- *  - `ITimesheet` interface describing the TypeScript shape.
- *  - `TimesheetSchema` defining the MongoDB document schema.
- *  - `Timesheet` Mongoose model for database interactions.
+ * ---------
+ * - `ITimesheet` interface: TypeScript representation of a timesheet document.
+ * - `TimesheetSchema`: Mongoose schema describing the persisted fields.
+ * - `Timesheet` model: Mongoose model exposing CRUD helpers.
+ *
+ * Key Interactions
+ * ----------------
+ * - Utilised by `routes/timesheets.ts` for creating and retrieving records.
+ * - Depends on an active Mongoose connection configured in `db.ts`.
+ *
+ * Assumptions
+ * -----------
+ * - `DB_URI` environment variable is set to a reachable MongoDB instance.
+ * - The database connection is established before this model is imported.
  */
+import { Schema, model, Document, Types } from 'mongoose';
 export interface ITimesheet extends Document {
   user: Types.ObjectId; // reference to the user who logged the hours
   hours: number;        // number of hours worked

--- a/backend/src/routes/leaves.ts
+++ b/backend/src/routes/leaves.ts
@@ -1,12 +1,27 @@
 /**
- * Mini readme: Leave routes
- * ------------------------
- * Provides endpoints for listing and managing leave requests. All routes
- * enforce authentication through the shared auth middleware. The GET handler
- * returns either all leave entries (for administrators and team admins) or
- * only the authenticated user's records. The POST handler validates required
- * fields before creating or updating leave records.
-*/
+ * @file Leave routes.
+ *
+ * Purpose
+ * -------
+ * REST endpoints for listing and managing leave requests.
+ *
+ * Structure
+ * ---------
+ * - Initialise an Express router.
+ * - Apply authentication middleware globally.
+ * - `GET /`: list leave records (admins see all, others only their own).
+ * - `POST /`: validate payload then create or update a leave entry.
+ *
+ * Key Interactions
+ * ----------------
+ * - Uses the `Leave` Mongoose model for data persistence.
+ * - Leverages `authMiddleware` and `requireRole` for JWT validation and role enforcement.
+ *
+ * Assumptions
+ * -----------
+ * - `JWT_SECRET` environment variable exists for token verification.
+ * - `DB_URI` environment variable supplies MongoDB connection details.
+ */
 import { Router, Response } from 'express';
 // express-validator enables declarative validation of incoming requests
 import { check, validationResult } from 'express-validator';

--- a/backend/src/routes/timesheets.ts
+++ b/backend/src/routes/timesheets.ts
@@ -1,11 +1,26 @@
 /**
- * Mini readme: Timesheet routes
- * -----------------------------
- * Exposes endpoints for listing and submitting timesheets. All routes are
- * protected by authentication middleware. The GET handler returns either all
- * timesheets (for admin roles) or only the authenticated user's entries.
- * The POST handler validates mandatory fields and allows admins to submit or
- * update timesheets on behalf of users.
+ * @file Timesheet routes.
+ *
+ * Purpose
+ * -------
+ * REST endpoints for listing and submitting timesheet records.
+ *
+ * Structure
+ * ---------
+ * - Initialise an Express router.
+ * - Apply authentication middleware to all routes.
+ * - `GET /`: list timesheets (admins see all, others only their own).
+ * - `POST /`: validate payload then create or update a record.
+ *
+ * Key Interactions
+ * ----------------
+ * - Uses the `Timesheet` Mongoose model for database access.
+ * - Relies on `authMiddleware` and `requireRole` for JWT validation and role checks.
+ *
+ * Assumptions
+ * -----------
+ * - `JWT_SECRET` environment variable is set for token verification.
+ * - `DB_URI` environment variable provides connectivity to MongoDB.
  */
 import { Router, Response } from 'express';
 // express-validator provides declarative request validation helpers


### PR DESCRIPTION
## Summary
- document timesheet model with purpose, structure, interactions, and env assumptions
- document leave model and REST routes, outlining interactions and required env vars
- expand timesheet routes file header with detailed purpose and assumptions

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_689fae9126108328b0721c155d83979c