### PR TITLE
Use favicon.svg for site icon

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -10,7 +10,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Admin Dashboard - Dash</title>
-  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
+  <!-- Browser tab icon -->
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -12,7 +12,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Dashboard - Dash</title>
-  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
+  <!-- Browser tab icon -->
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/frontend/favicon.svg
+++ b/frontend/favicon.svg
@@ -1,0 +1,5 @@
+<!--
+  Mini readme: Dash favicon
+  Standalone "D" character used as the site browser tab icon.
+-->
+<svg width="1492" height="1599" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" overflow="hidden"><g transform="translate(128 -270)"><text font-family="Rockwell,Rockwell_MSFontService,sans-serif" font-style="italic" font-weight="700" font-size="761" transform="matrix(1 0 0 1 329.199 1234)">D</text></g></svg>

--- a/frontend/img/dash-logo.svg
+++ b/frontend/img/dash-logo.svg
@@ -1,7 +1,7 @@
 <!--
-  Mini readme: Dash logo favicon
+  Mini readme: Dash logo asset
   Provides the brand wordmark with a leading triple bar symbol. Rendered as
-  SVG so it scales cleanly for the browser tab icon.
+  SVG so it scales cleanly for reuse across the UI.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 40">
   <text x="0" y="30" font-family="Cambria Math, 'Cambria Math_MSFontService', serif" font-style="oblique" font-weight="700" font-size="30">≡</text>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Dash</title>
-  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
+  <!-- Browser tab icon -->
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/frontend/learning-zone.html
+++ b/frontend/learning-zone.html
@@ -10,7 +10,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Learning Zone - Dash</title>
-  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
+  <!-- Browser tab icon -->
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -11,7 +11,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Login - Dash</title>
-  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
+  <!-- Browser tab icon -->
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/frontend/manage-profiles.html
+++ b/frontend/manage-profiles.html
@@ -10,7 +10,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Manage Profiles - Dash</title>
-  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
+  <!-- Browser tab icon -->
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/frontend/my-details.html
+++ b/frontend/my-details.html
@@ -11,7 +11,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>My Details - Dash</title>
-  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
+  <!-- Browser tab icon -->
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/frontend/pricing.html
+++ b/frontend/pricing.html
@@ -10,7 +10,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Pricing - Dash</title>
-  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
+  <!-- Browser tab icon -->
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/frontend/signup.html
+++ b/frontend/signup.html
@@ -10,7 +10,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Sign Up - Dash</title>
-  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
+  <!-- Browser tab icon -->
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/frontend/subscription.html
+++ b/frontend/subscription.html
@@ -10,7 +10,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>Subscription Details - Dash</title>
-  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
+  <!-- Browser tab icon -->
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/frontend/view-profile.html
+++ b/frontend/view-profile.html
@@ -11,7 +11,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
   <title>User Profile - Dash</title>
-  <link rel="icon" type="image/svg+xml" href="img/dash-logo.svg">
+  <!-- Browser tab icon -->
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Add dedicated `frontend/favicon.svg` with mini readme
- Point all HTML pages to the shared `favicon.svg`
- Clarify dash-logo asset documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb1d4cf90832893efba9f5de5efa5