### PR TITLE
Add project editor page and team-scoped project routes

### DIFF
--- a/backend/src/models/project.ts
+++ b/backend/src/models/project.ts
@@ -2,7 +2,10 @@ import { Schema, model, Document, Types } from 'mongoose';
 import { IWorkPackage, WorkPackage } from './workPackage';
 
 /**
- * Work project information including nested work packages and tasks.
+ * Mini readme: Project model
+ * -------------------------
+ * Represents a work project owned by a specific team. Projects contain nested
+ * work packages and tasks and track scheduling and cost information.
  */
 export interface IProject extends Document {
   name: string;
@@ -14,6 +17,7 @@ export interface IProject extends Document {
   cost: number;
   billable: boolean; // whether project time is billable
   status: 'todo' | 'in-progress' | 'done';
+  team: Types.ObjectId; // team that owns the project
   workPackages: Types.DocumentArray<IWorkPackage>;
 }
 
@@ -31,6 +35,7 @@ const ProjectSchema = new Schema<IProject>({
     enum: ['todo', 'in-progress', 'done'],
     default: 'todo'
   },
+  team: { type: Schema.Types.ObjectId, ref: 'Team', required: true },
   workPackages: [WorkPackage.schema]
 });
 

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -1,100 +1,150 @@
 import { Router } from 'express';
-import { authMiddleware, requireRole } from '../middleware/authMiddleware';
+import {
+  authMiddleware,
+  requireRole,
+  AuthRequest
+} from '../middleware/authMiddleware';
 import { Project } from '../models/project';
+
+/**
+ * Mini readme: Project routes
+ * --------------------------
+ * REST endpoints for managing projects, work packages and tasks. All
+ * operations are scoped to the authenticated user's team to prevent
+ * cross-team data access.
+ */
 
 const router = Router();
 
 // All project routes require authentication
 router.use(authMiddleware);
 
-// Fetch all projects
-router.get('/', async (_, res) => {
-  const list = await Project.find().exec();
+// Fetch all projects for the user's team
+router.get('/', async (req: AuthRequest, res) => {
+  const list = await Project.find({ team: req.user!.team }).exec();
   res.json(list);
 });
 
 // Retrieve a single project with nested details
-router.get('/:id', async (req, res) => {
-  const proj = await Project.findById(req.params.id).exec();
+router.get('/:id', async (req: AuthRequest, res) => {
+  const proj = await Project.findOne({
+    _id: req.params.id,
+    team: req.user!.team
+  }).exec();
   if (!proj) return res.status(404).json({ message: 'Project not found' });
   res.json(proj);
 });
 
 // Create or update a project
-router.post('/', requireRole(['admin', 'teamAdmin']), async (req, res) => {
+router.post('/', requireRole(['admin', 'teamAdmin']), async (req: AuthRequest, res) => {
   const { id, ...data } = req.body;
 
   if (id) {
-    const updated = await Project.findByIdAndUpdate(id, data, { new: true });
+    const updated = await Project.findOneAndUpdate(
+      { _id: id, team: req.user!.team },
+      data,
+      { new: true }
+    ).exec();
+    if (!updated) return res.status(404).json({ message: 'Project not found' });
     return res.status(201).json(updated);
   }
 
-  const project = new Project(data);
+  const project = new Project({ ...data, team: req.user!.team });
   await project.save();
   res.status(201).json(project);
 });
 
 // Remove a project
-router.delete('/:id', requireRole(['admin', 'teamAdmin']), async (req, res) => {
-  const del = await Project.findByIdAndDelete(req.params.id).exec();
+router.delete('/:id', requireRole(['admin', 'teamAdmin']), async (req: AuthRequest, res) => {
+  const del = await Project.findOneAndDelete({
+    _id: req.params.id,
+    team: req.user!.team
+  }).exec();
   if (!del) return res.status(404).json({ message: 'Project not found' });
   res.json({ message: 'Project deleted' });
 });
 
 // Add a work package to a project
-router.post('/:id/workpackages', requireRole(['admin', 'teamAdmin']), async (req, res) => {
-  const project = await Project.findById(req.params.id).exec();
-  if (!project) return res.status(404).json({ message: 'Project not found' });
-  project.workPackages.push(req.body);
-  await project.save();
-  res.status(201).json(project);
-});
+router.post(
+  '/:id/workpackages',
+  requireRole(['admin', 'teamAdmin']),
+  async (req: AuthRequest, res) => {
+    const project = await Project.findOne({
+      _id: req.params.id,
+      team: req.user!.team
+    }).exec();
+    if (!project) return res.status(404).json({ message: 'Project not found' });
+    project.workPackages.push(req.body);
+    await project.save();
+    res.status(201).json(project);
+  }
+);
 
 // Add a task to a work package and notify the owner
-router.post('/:id/workpackages/:wpId/tasks', requireRole(['admin', 'teamAdmin']), async (req, res) => {
-  const project = await Project.findById(req.params.id).exec();
-  if (!project) return res.status(404).json({ message: 'Project not found' });
-  const wp = project.workPackages.id(req.params.wpId);
-  if (!wp) return res.status(404).json({ message: 'Work package not found' });
-  wp.tasks.push(req.body);
-  await project.save();
+router.post(
+  '/:id/workpackages/:wpId/tasks',
+  requireRole(['admin', 'teamAdmin']),
+  async (req: AuthRequest, res) => {
+    const project = await Project.findOne({
+      _id: req.params.id,
+      team: req.user!.team
+    }).exec();
+    if (!project) return res.status(404).json({ message: 'Project not found' });
+    const wp = project.workPackages.id(req.params.wpId);
+    if (!wp) return res.status(404).json({ message: 'Work package not found' });
+    wp.tasks.push(req.body);
+    await project.save();
 
-  // Notify task owner via direct message channel if socket.io available
-  const io = req.app.get('io');
-  if (io) {
-    io.to(req.body.owner).emit('directMessage', {
-      from: 'system',
-      to: req.body.owner,
-      text: `New task assigned: ${req.body.name}`,
-      createdAt: new Date().toISOString(),
-      isSeen: false
-    });
+    // Notify task owner via direct message channel if socket.io available
+    const io = req.app.get('io');
+    if (io) {
+      io.to(req.body.owner).emit('directMessage', {
+        from: 'system',
+        to: req.body.owner,
+        text: `New task assigned: ${req.body.name}`,
+        createdAt: new Date().toISOString(),
+        isSeen: false
+      });
+    }
+
+    res.status(201).json(project);
   }
-
-  res.status(201).json(project);
-});
+);
 
 // Retrieve all work packages for a project
-router.get('/:id/workpackages', async (req, res) => {
-  const project = await Project.findById(req.params.id).exec();
+router.get('/:id/workpackages', async (req: AuthRequest, res) => {
+  const project = await Project.findOne({
+    _id: req.params.id,
+    team: req.user!.team
+  }).exec();
   if (!project) return res.status(404).json({ message: 'Project not found' });
   res.json(project.workPackages);
 });
 
 // Update details for a specific work package
-router.patch('/:id/workpackages/:wpId', requireRole(['admin', 'teamAdmin']), async (req, res) => {
-  const project = await Project.findById(req.params.id).exec();
-  if (!project) return res.status(404).json({ message: 'Project not found' });
-  const wp = project.workPackages.id(req.params.wpId);
-  if (!wp) return res.status(404).json({ message: 'Work package not found' });
-  Object.assign(wp, req.body);
-  await project.save();
-  res.json(wp);
-});
+router.patch(
+  '/:id/workpackages/:wpId',
+  requireRole(['admin', 'teamAdmin']),
+  async (req: AuthRequest, res) => {
+    const project = await Project.findOne({
+      _id: req.params.id,
+      team: req.user!.team
+    }).exec();
+    if (!project) return res.status(404).json({ message: 'Project not found' });
+    const wp = project.workPackages.id(req.params.wpId);
+    if (!wp) return res.status(404).json({ message: 'Work package not found' });
+    Object.assign(wp, req.body);
+    await project.save();
+    res.json(wp);
+  }
+);
 
 // Retrieve a single work package
-router.get('/:id/workpackages/:wpId', async (req, res) => {
-  const project = await Project.findById(req.params.id).exec();
+router.get('/:id/workpackages/:wpId', async (req: AuthRequest, res) => {
+  const project = await Project.findOne({
+    _id: req.params.id,
+    team: req.user!.team
+  }).exec();
   if (!project) return res.status(404).json({ message: 'Project not found' });
   const wp = project.workPackages.id(req.params.wpId);
   if (!wp) return res.status(404).json({ message: 'Work package not found' });
@@ -102,32 +152,49 @@ router.get('/:id/workpackages/:wpId', async (req, res) => {
 });
 
 // Remove a work package
-router.delete('/:id/workpackages/:wpId', requireRole(['admin', 'teamAdmin']), async (req, res) => {
-  const project = await Project.findById(req.params.id).exec();
-  if (!project) return res.status(404).json({ message: 'Project not found' });
-  const wp = project.workPackages.id(req.params.wpId);
-  if (!wp) return res.status(404).json({ message: 'Work package not found' });
-  wp.deleteOne();
-  await project.save();
-  res.json({ message: 'Work package removed' });
-});
+router.delete(
+  '/:id/workpackages/:wpId',
+  requireRole(['admin', 'teamAdmin']),
+  async (req: AuthRequest, res) => {
+    const project = await Project.findOne({
+      _id: req.params.id,
+      team: req.user!.team
+    }).exec();
+    if (!project) return res.status(404).json({ message: 'Project not found' });
+    const wp = project.workPackages.id(req.params.wpId);
+    if (!wp) return res.status(404).json({ message: 'Work package not found' });
+    wp.deleteOne();
+    await project.save();
+    res.json({ message: 'Work package removed' });
+  }
+);
 
 // Update individual tasks within a work package
-router.patch('/:id/workpackages/:wpId/tasks/:taskId', requireRole(['admin', 'teamAdmin']), async (req, res) => {
-  const project = await Project.findById(req.params.id).exec();
-  if (!project) return res.status(404).json({ message: 'Project not found' });
-  const wp = project.workPackages.id(req.params.wpId);
-  if (!wp) return res.status(404).json({ message: 'Work package not found' });
-  const task = wp.tasks.id(req.params.taskId);
-  if (!task) return res.status(404).json({ message: 'Task not found' });
-  Object.assign(task, req.body);
-  await project.save();
-  res.json(task);
-});
+router.patch(
+  '/:id/workpackages/:wpId/tasks/:taskId',
+  requireRole(['admin', 'teamAdmin']),
+  async (req: AuthRequest, res) => {
+    const project = await Project.findOne({
+      _id: req.params.id,
+      team: req.user!.team
+    }).exec();
+    if (!project) return res.status(404).json({ message: 'Project not found' });
+    const wp = project.workPackages.id(req.params.wpId);
+    if (!wp) return res.status(404).json({ message: 'Work package not found' });
+    const task = wp.tasks.id(req.params.taskId);
+    if (!task) return res.status(404).json({ message: 'Task not found' });
+    Object.assign(task, req.body);
+    await project.save();
+    res.json(task);
+  }
+);
 
 // Retrieve a single task from a work package
-router.get('/:id/workpackages/:wpId/tasks/:taskId', async (req, res) => {
-  const project = await Project.findById(req.params.id).exec();
+router.get('/:id/workpackages/:wpId/tasks/:taskId', async (req: AuthRequest, res) => {
+  const project = await Project.findOne({
+    _id: req.params.id,
+    team: req.user!.team
+  }).exec();
   if (!project) return res.status(404).json({ message: 'Project not found' });
   const wp = project.workPackages.id(req.params.wpId);
   if (!wp) return res.status(404).json({ message: 'Work package not found' });
@@ -137,16 +204,23 @@ router.get('/:id/workpackages/:wpId/tasks/:taskId', async (req, res) => {
 });
 
 // Remove an individual task
-router.delete('/:id/workpackages/:wpId/tasks/:taskId', requireRole(['admin', 'teamAdmin']), async (req, res) => {
-  const project = await Project.findById(req.params.id).exec();
-  if (!project) return res.status(404).json({ message: 'Project not found' });
-  const wp = project.workPackages.id(req.params.wpId);
-  if (!wp) return res.status(404).json({ message: 'Work package not found' });
-  const task = wp.tasks.id(req.params.taskId);
-  if (!task) return res.status(404).json({ message: 'Task not found' });
-  task.deleteOne();
-  await project.save();
-  res.json({ message: 'Task removed' });
-});
+router.delete(
+  '/:id/workpackages/:wpId/tasks/:taskId',
+  requireRole(['admin', 'teamAdmin']),
+  async (req: AuthRequest, res) => {
+    const project = await Project.findOne({
+      _id: req.params.id,
+      team: req.user!.team
+    }).exec();
+    if (!project) return res.status(404).json({ message: 'Project not found' });
+    const wp = project.workPackages.id(req.params.wpId);
+    if (!wp) return res.status(404).json({ message: 'Work package not found' });
+    const task = wp.tasks.id(req.params.taskId);
+    if (!task) return res.status(404).json({ message: 'Task not found' });
+    task.deleteOne();
+    await project.save();
+    res.json({ message: 'Task removed' });
+  }
+);
 
 export default router;

--- a/backend/test/timesheets.test.ts
+++ b/backend/test/timesheets.test.ts
@@ -47,7 +47,12 @@ describe('timesheet routes', () => {
     regularUser = await new User({ username: 'user@test.com', password: hashed, role: 'user', team }).save();
 
     // Create a sample project to reference in timesheets
-    project = await new Project({ name: 'Alpha', owner: 'admin@test.com', billable: true }).save();
+    project = await new Project({
+      name: 'Alpha',
+      owner: 'admin@test.com',
+      billable: true,
+      team: team._id
+    }).save();
 
     // Generate JWTs for both users
     adminToken = jwt.sign(

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -90,51 +90,8 @@
       </section>
       <section id="projects" class="hidden">
         <h2>Projects</h2>
-        <form id="projectForm" class="card">
-          <input id="projectId" type="hidden" />
-          <input id="projectName" placeholder="Project name" required />
-          <input id="projectOwner" placeholder="Owner" required />
-          <input id="projectStart" type="date" />
-          <input id="projectEnd" type="date" />
-          <input id="projectHours" type="number" placeholder="Hours" />
-          <input id="projectCost" type="number" placeholder="£ Cost" />
-          <label><input id="projectBillable" type="checkbox" checked /> Billable</label>
-          <textarea id="projectDesc" placeholder="Description"></textarea>
-          <button type="submit">Save</button>
-        </form>
-
-        <div id="workPackageSection" class="hidden">
-          <h3>Work Packages</h3>
-          <form id="workPackageForm" class="card">
-            <input id="wpProject" type="hidden" />
-            <input id="wpId" type="hidden" />
-            <input id="wpName" placeholder="Work package name" required />
-            <input id="wpOwner" placeholder="Owner" />
-            <input id="wpStart" type="date" />
-            <input id="wpEnd" type="date" />
-            <input id="wpHours" type="number" placeholder="Hours" />
-            <input id="wpCost" type="number" placeholder="£ Cost" />
-            <button type="submit">Save Work Package</button>
-          </form>
-          <table class="admin-table" id="workPackageTable"></table>
-
-          <h4>Tasks</h4>
-          <form id="taskForm" class="card">
-            <input id="taskProject" type="hidden" />
-            <input id="taskWp" type="hidden" />
-            <input id="taskId" type="hidden" />
-            <input id="taskName" placeholder="Task name" required />
-            <input id="taskOwner" placeholder="Owner" />
-            <input id="taskStart" type="date" />
-            <input id="taskEnd" type="date" />
-            <input id="taskHours" type="number" placeholder="Hours" />
-            <input id="taskCost" type="number" placeholder="£ Cost" />
-            <button type="submit">Save Task</button>
-          </form>
-          <table class="admin-table" id="taskTable"></table>
-        </div>
-        <div id="gantt"></div>
         <table class="admin-table" id="projectTable"></table>
+        <button id="addProjectButton">Add New Project</button>
       </section>
       <section id="timesheets" class="hidden">
         <h2>Timesheets</h2>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -120,7 +120,6 @@ function selectTool(tool) {
 
   if (tool === 'projects') {
     loadProjects();
-    resetProjectForm();
   }
 
   if (tool === 'timesheets') {
@@ -322,7 +321,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Dashboard-specific initialisation. All listeners are attached here to
   // satisfy the strict CSP which forbids inline event handlers.
-  if (document.getElementById('tool-messages')) {
+  const dashboardRoot = document.getElementById('tool-messages');
+  if (dashboardRoot) {
     document.querySelectorAll('.tool-sidebar li').forEach(li => {
       li.addEventListener('click', () => {
         const tool = li.id.replace('tool-', '');
@@ -354,13 +354,6 @@ document.addEventListener('DOMContentLoaded', () => {
         saveContact(e);
       });
 
-    const projectForm = document.getElementById('projectForm');
-    if (projectForm)
-      projectForm.addEventListener('submit', e => {
-        e.preventDefault();
-        saveProject(e);
-      });
-
     const timesheetForm = document.getElementById('timesheetForm');
     if (timesheetForm)
       timesheetForm.addEventListener('submit', e => {
@@ -387,20 +380,6 @@ document.addEventListener('DOMContentLoaded', () => {
         saveLeave(e);
       });
 
-    const workPackageForm = document.getElementById('workPackageForm');
-    if (workPackageForm)
-      workPackageForm.addEventListener('submit', e => {
-        e.preventDefault();
-        saveWorkPackage(e);
-      });
-
-    const taskForm = document.getElementById('taskForm');
-    if (taskForm)
-      taskForm.addEventListener('submit', e => {
-        e.preventDefault();
-        saveTask(e);
-      });
-
     const postForm = document.getElementById('postForm');
     if (postForm)
       postForm.addEventListener('submit', e => {
@@ -408,6 +387,33 @@ document.addEventListener('DOMContentLoaded', () => {
         savePost(e);
       });
   }
+
+  const projectForm = document.getElementById('projectForm');
+  if (projectForm)
+    projectForm.addEventListener('submit', e => {
+      e.preventDefault();
+      saveProject(e);
+    });
+
+  const workPackageForm = document.getElementById('workPackageForm');
+  if (workPackageForm)
+    workPackageForm.addEventListener('submit', e => {
+      e.preventDefault();
+      saveWorkPackage(e);
+    });
+
+  const taskForm = document.getElementById('taskForm');
+  if (taskForm)
+    taskForm.addEventListener('submit', e => {
+      e.preventDefault();
+      saveTask(e);
+    });
+
+  const addProjectBtn = document.getElementById('addProjectButton');
+  if (addProjectBtn)
+    addProjectBtn.addEventListener('click', () => {
+      window.location.href = 'project.html';
+    });
 });
 
 function sendMessage() {
@@ -1026,7 +1032,7 @@ function loadProjects() {
           <td>${escapeHtml(p.name)}</td>
           <td>${escapeHtml(p.owner)}</td>
           <td>${escapeHtml(p.status)}</td>
-          <td><button onclick="editProject('${p._id}')">Edit</button></td>`;
+          <td><a href="project.html?id=${p._id}">Edit</a> <button onclick="deleteProject('${p._id}')">Delete</button></td>`;
         table.appendChild(row);
         // Collect tasks for gantt chart
         if (p.workPackages) {
@@ -1043,7 +1049,9 @@ function loadProjects() {
         }
       });
 
-      renderGantt(tasks);
+      if (document.getElementById('gantt')) {
+        renderGantt(tasks);
+      }
       populateTimesheetProjects();
     });
 }
@@ -1089,8 +1097,19 @@ function saveProject(e) {
     body: JSON.stringify({ id, name, owner, start, end, hours, cost, billable, description })
   }).then(() => {
     resetProjectForm();
-    loadProjects();
+    if (document.getElementById('projectTable')) {
+      loadProjects();
+    }
   });
+}
+
+// Remove a project after confirmation
+function deleteProject(id) {
+  if (!confirm('Delete this project?')) return;
+  fetch(`${API_BASE_URL}/api/projects/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${currentUser.token}` }
+  }).then(() => loadProjects());
 }
 
 // ----------------------- Work package helpers -----------------------

--- a/frontend/js/project-page.js
+++ b/frontend/js/project-page.js
@@ -1,0 +1,18 @@
+/**
+ * Mini readme: Project page initialiser
+ * ------------------------------------
+ * Reads the `id` query parameter to load an existing project for editing
+ * using helper functions from app.js. When no `id` is supplied the project
+ * form is reset to create a new project. This file attaches no event
+ * listeners itself; app.js handles form submissions and API requests.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  const id = params.get('id');
+  if (id) {
+    editProject(id);
+  } else {
+    resetProjectForm();
+  }
+});

--- a/frontend/project.html
+++ b/frontend/project.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!--
+    Mini readme: Project editor page
+    Provides full CRUD interface for a single project including nested work
+    packages and tasks. Accessible via links from the dashboard's Projects tab.
+    Use the `id` query parameter to edit an existing project or leave blank to
+    create a new one. Requires authentication and relies on app.js for API
+    interactions.
+  -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws:;">
+  <title>Project Editor - Dash</title>
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="dashboard.html" class="wordmark">Dash</a>
+      <div class="profile">
+        <img id="navAvatar" class="avatar profile-button" alt="Profile menu" />
+        <ul id="profileMenu" class="profile-menu hidden">
+          <li><a href="manage-profiles.html">Manage Profiles</a></li>
+          <li><a href="learning-zone.html">Learning Zone</a></li>
+          <li><a href="view-profile.html?id=me">View Profile Page</a></li>
+          <li><a href="my-details.html">My Details</a></li>
+          <li><a href="subscription.html">Subscription Details</a></li>
+          <li id="manageUsersLink" class="hidden"><a href="admin.html">Manage Users</a></li>
+          <li><a href="#" id="logoutLink">Sign out</a></li>
+        </ul>
+      </div>
+    </nav>
+  </header>
+
+  <main class="content">
+    <h2>Project Details</h2>
+    <form id="projectForm" class="card">
+      <input id="projectId" type="hidden" />
+      <input id="projectName" placeholder="Project name" required />
+      <input id="projectOwner" placeholder="Owner" required />
+      <input id="projectStart" type="date" />
+      <input id="projectEnd" type="date" />
+      <input id="projectHours" type="number" placeholder="Hours" />
+      <input id="projectCost" type="number" placeholder="£ Cost" />
+      <label><input id="projectBillable" type="checkbox" checked /> Billable</label>
+      <textarea id="projectDesc" placeholder="Description"></textarea>
+      <button type="submit">Save Project</button>
+    </form>
+
+    <div id="workPackageSection" class="hidden">
+      <h3>Work Packages</h3>
+      <form id="workPackageForm" class="card">
+        <input id="wpProject" type="hidden" />
+        <input id="wpId" type="hidden" />
+        <input id="wpName" placeholder="Work package name" required />
+        <input id="wpOwner" placeholder="Owner" />
+        <input id="wpStart" type="date" />
+        <input id="wpEnd" type="date" />
+        <input id="wpHours" type="number" placeholder="Hours" />
+        <input id="wpCost" type="number" placeholder="£ Cost" />
+        <button type="submit">Save Work Package</button>
+      </form>
+      <table class="admin-table" id="workPackageTable"></table>
+
+      <h4>Tasks</h4>
+      <form id="taskForm" class="card">
+        <input id="taskProject" type="hidden" />
+        <input id="taskWp" type="hidden" />
+        <input id="taskId" type="hidden" />
+        <input id="taskName" placeholder="Task name" required />
+        <input id="taskOwner" placeholder="Owner" />
+        <input id="taskStart" type="date" />
+        <input id="taskEnd" type="date" />
+        <input id="taskHours" type="number" placeholder="Hours" />
+        <input id="taskCost" type="number" placeholder="£ Cost" />
+        <button type="submit">Save Task</button>
+      </form>
+      <table class="admin-table" id="taskTable"></table>
+    </div>
+  </main>
+
+  <script src="js/app.js"></script>
+  <script src="js/project-page.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone project editor with work package and task management
- show team-scoped project list with edit and delete actions
- ensure project API and tests include team ownership

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a03e79bd308328b931f64e166535db