### PR TITLE
Improve setup instructions and add unified automation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,219 +1,155 @@
 # Dash
 
-## Overview
-Dash is an example enterprise web platform demonstrating several features:
+Dash is a full-stack enterprise demo platform showcasing secure messaging, CRM, project tracking, and workforce management in a single responsive web experience. The backend is an Express + TypeScript API backed by MongoDB, while the frontend is a static site served by any modern web server.
 
-- Instant messaging with multiple channels, presence indicators and message editing
-- Basic CRM with contact management, company/notes fields and project/program tracking
-- Full project management with work packages and tasks
-- Timesheets and leave requests
-- Team management with seat limits and email invitations
-- Simple sign-up flow that creates teams with dummy payment processing
-- Role-based authentication with admin, team admin and user levels
-- Browser-based UI designed to be responsive and mobile friendly with a consistent card layout
-- Dockerised backend for easy deployment
+---
 
-## Prerequisites
-Dash requires Node.js 18+, npm, Docker and access to a MongoDB database.
+## 0. Prerequisites (do this once per machine)
 
-### Install Node.js
-#### Windows
-1. Install [nvm for Windows](https://github.com/coreybutler/nvm-windows) or download the LTS installer from [nodejs.org](https://nodejs.org/).
-2. Use nvm to install Node.js 18:
-   ```powershell
-   nvm install 18
-   nvm use 18
-   ```
-3. Verify installation:
-   ```powershell
-   node -v
-   npm -v
-   ```
+| Requirement | Windows guidance | Linux / Raspberry Pi guidance |
+| --- | --- | --- |
+| **Git** | Install with [Git for Windows](https://git-scm.com/download/win) or `winget install Git.Git`. | Install via your package manager, e.g. `sudo apt install git`. |
+| **Node.js 18+ & npm** | Use [nvm for Windows](https://github.com/coreybutler/nvm-windows) so each project has an isolated runtime:<br>`nvm install 20.11.1`<br>`nvm use 20.11.1` | Install [nvm](https://github.com/nvm-sh/nvm):<br>`curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash`<br>`source ~/.nvm/nvm.sh`<br>`nvm install 20.11.1` |
+| **MongoDB 6+** | Install [MongoDB Community Server](https://www.mongodb.com/try/download/community) or use Docker Desktop (`docker run -d --name mongo -p 27017:27017 mongo:6`). | Install packages (`sudo apt install mongodb`) **or** run the same Docker command as Windows. |
+| **Docker (optional)** | Recommended for running MongoDB quickly: `winget install Docker.DockerDesktop`. | Install using the convenience script:<br>`curl -fsSL https://get.docker.com -o get-docker.sh`<br>`sudo sh get-docker.sh`<br>`sudo usermod -aG docker $USER` |
 
-#### Linux/Raspberry Pi
-1. Install nvm and Node.js 18:
-   ```bash
-   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
-   source ~/.nvm/nvm.sh
-   nvm install 18
-   ```
-2. Confirm with:
-   ```bash
-   node -v
-   npm -v
-   ```
+> ℹ️ Treat nvm as your "virtual environment" for Node projects: activate your Node version with `nvm use 20.11.1` before working on Dash.
 
-### Install Docker
-#### Windows
-1. Install Docker Desktop from <https://www.docker.com/products/docker-desktop/> or via `winget`:
-   ```powershell
-   winget install Docker.DockerDesktop
-   ```
-2. Start Docker Desktop and ensure it works:
-   ```powershell
-   docker --version
-   ```
+After installation, verify versions:
 
-#### Linux/Raspberry Pi
-1. Run the convenience script:
-   ```bash
-   curl -fsSL https://get.docker.com -o get-docker.sh
-   sudo sh get-docker.sh
-   sudo usermod -aG docker $USER
-   ```
-2. Log out and back in, then verify:
-   ```bash
-   docker --version
-   ```
+- Windows PowerShell:
+  ```powershell
+  node -v
+  npm -v
+  mongod --version
+  ```
+- Linux / Raspberry Pi:
+  ```bash
+  node -v
+  npm -v
+  mongod --version
+  ```
 
-### Install MongoDB
-#### Windows
-1. Install MongoDB Community Server from <https://www.mongodb.com/try/download/community> or with `winget`:
-   ```powershell
-   winget install MongoDB.MongoDBServer
-   ```
-2. Start the MongoDB service and check:
-   ```powershell
-   mongod --version
-   ```
+---
 
-#### Linux/Raspberry Pi
-1. On Debian/Ubuntu systems:
-   ```bash
-   sudo apt update
-   sudo apt install -y mongodb
-   sudo systemctl enable --now mongodb
-   ```
-   If packages are unavailable or you prefer Docker:
-   ```bash
-   docker run -d --name mongo -p 27017:27017 -v mongo-data:/data/db mongo:6
-   ```
-2. Verify with:
-   ```bash
-   mongod --version   # or: docker ps
-   ```
+## 1. One-time project setup
 
-## Project Setup
-1. Clone this repository.
-2. Copy `backend/.env.example` to `backend/.env` and set `DB_URI` to your MongoDB connection string. Create a `JWT_SECRET` for token signing:
-   - Generate a 32‑byte secret (works on Windows, Linux and Raspberry Pi):
-     ```bash
-     node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+1. **Clone the repository.**
+   - Windows PowerShell:
+     ```powershell
+     git clone https://github.com/your-org/Dash.git
+     cd Dash
      ```
-   - Add the output to `backend/.env`:
-     - **Linux/Raspberry Pi/macOS:**
-       ```bash
-       echo "JWT_SECRET=<paste-output>" >> backend/.env
-       ```
-     - **Windows PowerShell:**
-       ```powershell
-       Add-Content backend/.env "`nJWT_SECRET=<paste-output>"
-       ```
-   The start scripts will generate a secret automatically if one is missing and display it in the console.
-3. Install dependencies from the repository root (this installs the backend automatically):
-   ```bash
-   npm install
-   ```
-   You can still install directly in the backend directory if preferred:
-   ```bash
-   cd backend
-   npm install
-   ```
+   - Linux / Raspberry Pi:
+     ```bash
+     git clone https://github.com/your-org/Dash.git
+     cd Dash
+     ```
 
-## Running the App
+2. **Prepare configuration and install dependencies using the unified helper script.** This creates `backend/.env`, generates a secure `JWT_SECRET`, installs Node packages, and optionally updates your MongoDB URI.
+   - Windows PowerShell:
+     ```powershell
+     node scripts/manage-dash.mjs setup --db-uri "mongodb://localhost:27017/dash"
+     ```
+   - Linux / Raspberry Pi:
+     ```bash
+     node scripts/manage-dash.mjs setup --db-uri "mongodb://localhost:27017/dash"
+     ```
 
-### Quick Start Scripts
-#### Windows
-Run the PowerShell script to install dependencies, initialise the database, attempt to launch a local MongoDB instance via Docker, build and start the backend:
+   Advanced flags:
+   - `--skip-install` if you have already run `npm install`.
+   - `--init-db` to execute `npm run db:init` immediately after dependencies install (MongoDB must be running).
 
-```powershell
-powershell -ExecutionPolicy Bypass -File .\start-windows.ps1 -port 4000
-```
+The script logs every action to `./logs/manage-dash.log`, making debugging straightforward if something fails.
 
-Options:
+---
 
-- `-port` — port to run the server (default `3000`)
-- `-prod` — run in production mode
-- `-dbUri` — specify an external MongoDB URI
+## 2. Launching the platform (repeat whenever you want to run Dash)
 
-If `backend/.env` does not contain `JWT_SECRET`, the script generates one and prints it. All output is logged to `dash_windows_start.log`.
+> Ensure your MongoDB instance is running before starting the app. For Docker users: `docker start mongo`.
 
-#### Raspberry Pi / Linux
-The `dash-start-rpi.sh` script installs Node.js 18 if required, installs dependencies, initialises the database, builds the code and launches the server. It also tries to start MongoDB in Docker if no local instance is detected.
+### Development mode (auto-reload, verbose logging)
 
-```bash
-chmod +x ./dash-start-rpi.sh
-./dash-start-rpi.sh --port 4000        # development mode
-./dash-start-rpi.sh --port 4000 --prod # production mode
-```
+- Windows PowerShell:
+  ```powershell
+  node scripts/manage-dash.mjs start --mode dev --port 3000
+  ```
+- Linux / Raspberry Pi:
+  ```bash
+  node scripts/manage-dash.mjs start --mode dev --port 3000
+  ```
 
-If no `JWT_SECRET` is found in `backend/.env`, the script creates one and displays it. Logs are written to `dash_rpi_start.log`.
+The API listens on the requested port (defaults to `3000` if omitted) and reloads automatically when backend TypeScript files change.
 
-### Manual Run
-1. Ensure `DB_URI` and `JWT_SECRET` are set (either in `backend/.env` or exported in the shell).
-2. Initialise the database:
-   ```bash
-   cd backend
-   npm run db:init
-   ```
-3. Build and start the server:
-   ```bash
-   npm run build
-   npm start
-   ```
+### Production simulation (build + run compiled JavaScript)
 
-Browse to `http://localhost:3000`. The frontend uses `window.location.origin` for API requests, so it points to the host that served the page. If your backend runs elsewhere, update `API_BASE_URL` in `frontend/js/app.js`.
+- Windows PowerShell:
+  ```powershell
+  node scripts/manage-dash.mjs start --mode prod --port 4000
+  ```
+- Linux / Raspberry Pi:
+  ```bash
+  node scripts/manage-dash.mjs start --mode prod --port 4000
+  ```
 
-### Docker Container
-To build and run the backend in Docker:
+This command performs a TypeScript build before launching the compiled server with `NODE_ENV=production`.
+
+### Optional: seed demo data after launch
+
+If you want to seed demo data (requires MongoDB online), append `--init-db`:
 
 ```bash
-docker build -t dash-backend ./backend
-docker run -p 3000:3000 -e DB_URI=mongodb://localhost:27017/dash dash-backend
+node scripts/manage-dash.mjs start --mode dev --init-db
 ```
 
-Serve the frontend with any static web server.
+> The helper script respects environment variables. For example, setting `CORS_ORIGIN="https://dash.example.com"` before running ensures the API only accepts requests from that host.
 
-## Admin Configuration
-Administrators can manage runtime settings via the `/api/admin/config` endpoints:
+---
 
-- `POST /api/admin/config` – create or update a configuration value
-- `GET /api/admin/config` – list all stored configuration values
+## 3. Serving the frontend
 
-A default administrator account is seeded for demo purposes:
+The frontend files under `frontend/` are static. During development you can open `frontend/index.html` directly or serve them with any static server (e.g. `npx serve frontend`). In production deployments place the files behind a CDN or web server of your choice (NGINX, S3 + CloudFront, etc.). The frontend automatically targets the origin it was loaded from, so host the API and static files on the same domain or configure `API_BASE_URL` in `frontend/js/app.js`.
+
+---
+
+## 4. Helpful npm scripts
+
+| Command | What it does |
+| --- | --- |
+| `npm run dash:setup` | Shortcut for `node scripts/manage-dash.mjs setup`. |
+| `npm run dash:start` | Shortcut for `node scripts/manage-dash.mjs start`. |
+| `npm run dev --prefix backend` | Runs the backend in watch mode without the helper script. |
+| `npm run build --prefix backend` | Compiles TypeScript to `backend/dist`. |
+| `npm run db:init --prefix backend` | Seeds MongoDB with demo data (ensure the database is reachable). |
+| `npm test --prefix backend` | Executes Jest tests. |
+
+---
+
+## 5. Default admin account
+
+For demo access the backend seeds an administrator profile:
 
 - **Username:** `admin`
 - **Password:** `Admin12345`
 
-After logging in, visit `/admin.html` to access the dashboard for managing configuration values, teams and users.
+After signing in, navigate to `/admin.html` to manage configuration, teams, and users.
 
-## Troubleshooting
-- If a start script fails, review `dash_windows_start.log` or `dash_rpi_start.log` for details.
-- When the backend cannot reach MongoDB it prints the connection URI it attempted, making configuration issues easier to spot.
-- Seeing `Too many requests, please try again later.` means the API rate limiter was triggered. Increase `GENERAL_RATE_LIMIT_MAX_REQUESTS`
-  or enlarge `GENERAL_RATE_LIMIT_WINDOW_MINUTES` in your environment configuration, then restart the backend.
+---
 
-### Rate limiting configuration
-The backend ships with sensible defaults but allows full control over rate limiting through environment variables:
+## 6. Troubleshooting & diagnostics
 
-| Variable | Purpose | Default |
-| --- | --- | --- |
-| `GENERAL_RATE_LIMIT_WINDOW_MINUTES` | Minutes in each window for general `/api` traffic. | `1` |
-| `GENERAL_RATE_LIMIT_MAX_REQUESTS` | Requests allowed per IP in each general window. | `600` |
-| `AUTH_RATE_LIMIT_WINDOW_MINUTES` | Minutes in each window for `/api/auth/login`. | `15` |
-| `AUTH_RATE_LIMIT_MAX_REQUESTS` | Login attempts allowed per IP before throttling. | `20` |
+- Review `./logs/manage-dash.log` for a timestamped history of every setup/start action.
+- If the helper script reports `Command failed`, scroll up in the terminal for the failing step and re-run with `--skip-install` to avoid repeating earlier success.
+- Connection errors will echo the MongoDB URI Dash attempted. Confirm the URI in `backend/.env` and verify MongoDB is running.
+- Rate limiting is configurable through `GENERAL_RATE_LIMIT_*` and `AUTH_RATE_LIMIT_*` variables in `backend/.env`. Restart the server after changes.
+- Press `Ctrl+C` to stop the running server. On Windows, you might need to press it twice to fully terminate nodemon.
 
-Set the values in `backend/.env` or via your shell prior to starting the backend:
+---
 
-```powershell
-# Windows PowerShell
-Add-Content -Path .\backend\.env -Value "GENERAL_RATE_LIMIT_MAX_REQUESTS=900"
-```
+## 7. Architecture quick reference
 
-```bash
-# Linux / Raspberry Pi
-echo "GENERAL_RATE_LIMIT_MAX_REQUESTS=900" >> ./backend/.env
-```
+- **Backend:** `backend/src/index.ts` exposes the Express server, Socket.IO integration, and security middleware.
+- **Frontend:** static HTML/CSS/JS in `frontend/` communicates with the backend via REST and WebSocket endpoints.
+- **Scripts:** `scripts/manage-dash.mjs` centralises setup/start automation for all platforms.
 
-Restart the backend after making changes so the new limits load. The server logs the effective configuration on boot, helping you
-verify your settings.
+For deeper code documentation, consult the inline comments at the top of each source file; every file contains a mini README explaining its purpose and layout.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build": "npm run build --prefix backend",
     "dev": "npm run dev --prefix backend",
     "db:init": "npm run db:init --prefix backend",
-    "test": "npm test --prefix backend"
+    "test": "npm test --prefix backend",
+    "dash:setup": "node scripts/manage-dash.mjs setup",
+    "dash:start": "node scripts/manage-dash.mjs start"
   }
 }

--- a/scripts/manage-dash.mjs
+++ b/scripts/manage-dash.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview Dash lifecycle helper script (mini README).
+ *
+ * PURPOSE
+ * -------
+ * Provide a single, cross-platform entry point for preparing and launching the Dash
+ * platform. The script encapsulates the one-time setup workflow (installing
+ * dependencies and preparing environment variables) and the repeatable startup
+ * tasks for development or production modes.
+ *
+ * STRUCTURE
+ * ---------
+ * - Argument parsing converts CLI flags into a normalized options object.
+ * - High-level actions (`handleSetup`, `handleStart`) orchestrate the workflow.
+ * - Shared helpers (`runCommand`, `ensureEnvConfig`, logging utilities) handle
+ *   process execution, environment file management, and debug-friendly logging.
+ *
+ * USAGE EXAMPLES
+ * --------------
+ * node scripts/manage-dash.mjs setup --db-uri "mongodb://localhost:27017/dash"
+ * node scripts/manage-dash.mjs start --mode dev --port 3100
+ * node scripts/manage-dash.mjs start --mode prod --port 4000 --init-db
+ *
+ * KEY FILES & LOGGING
+ * -------------------
+ * - Writes logs to ./logs/manage-dash.log for troubleshooting.
+ * - Ensures backend/.env exists (copying from backend/.env.example if needed) and
+ *   auto-generates a secure JWT secret when missing or left as the placeholder.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import crypto from 'node:crypto';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT_DIR = resolve(__dirname, '..');
+const BACKEND_DIR = resolve(ROOT_DIR, 'backend');
+const ENV_PATH = resolve(BACKEND_DIR, '.env');
+const ENV_EXAMPLE_PATH = resolve(BACKEND_DIR, '.env.example');
+const LOG_DIR = resolve(ROOT_DIR, 'logs');
+const LOG_PATH = resolve(LOG_DIR, 'manage-dash.log');
+
+/** Timestamped console + file logger for consistent diagnostics. */
+function log(message) {
+  const timestamp = new Date().toISOString();
+  const line = `[${timestamp}] ${message}`;
+  console.log(line);
+  appendToLog(`${line}\n`);
+}
+
+function appendToLog(content) {
+  if (!existsSync(LOG_DIR)) {
+    mkdirSync(LOG_DIR, { recursive: true });
+  }
+  appendFileSync(LOG_PATH, content, { encoding: 'utf8' });
+}
+
+/** Write raw process output to both stdout/stderr and the log file. */
+function logProcessStream(stream, prefix = '', target = process.stdout) {
+  stream.on('data', chunk => {
+    const text = chunk.toString();
+    target.write(text);
+    const lines = text.split(/\r?\n/).filter(Boolean);
+    lines.forEach(line => appendToLog(`${prefix}${line}\n`));
+  });
+}
+
+/** Execute an external command with inherit-style streaming and logging. */
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const display = `${command} ${args.join(' ')}`.trim();
+    log(`Running command: ${display}`);
+    const child = spawn(command, args, {
+      cwd: options.cwd || ROOT_DIR,
+      env: options.env || process.env,
+      shell: process.platform === 'win32',
+      stdio: ['inherit', 'pipe', 'pipe']
+    });
+
+    logProcessStream(child.stdout);
+    logProcessStream(child.stderr, '[stderr] ', process.stderr);
+
+    child.on('error', err => {
+      log(`Process error: ${err.message}`);
+      reject(err);
+    });
+
+    child.on('close', code => {
+      if (code === 0) {
+        log(`Command succeeded: ${display}`);
+        resolve();
+      } else {
+        const error = new Error(`Command failed with exit code ${code}: ${display}`);
+        log(error.message);
+        reject(error);
+      }
+    });
+  });
+}
+
+/** Parse CLI arguments into command + options. */
+function parseArguments(argv) {
+  const args = [...argv];
+  let command = 'start';
+  if (args.length > 0 && !args[0].startsWith('--')) {
+    command = args.shift();
+  }
+
+  const options = {
+    mode: 'dev',
+    port: null,
+    dbUri: null,
+    skipInstall: false,
+    initDb: false,
+    help: false
+  };
+
+  while (args.length > 0) {
+    const raw = args.shift();
+    switch (raw) {
+      case '--mode':
+        options.mode = (args.shift() || '').toLowerCase();
+        break;
+      case '--mode=dev':
+      case '--mode=prod':
+        options.mode = raw.split('=')[1];
+        break;
+      case '--port':
+        options.port = Number(args.shift());
+        break;
+      default:
+        if (raw.startsWith('--port=')) {
+          options.port = Number(raw.split('=')[1]);
+        } else if (raw === '--db-uri') {
+          options.dbUri = args.shift() || null;
+        } else if (raw.startsWith('--db-uri=')) {
+          options.dbUri = raw.split('=')[1];
+        } else if (raw === '--skip-install') {
+          options.skipInstall = true;
+        } else if (raw === '--init-db') {
+          options.initDb = true;
+        } else if (raw === '--help' || raw === '-h') {
+          options.help = true;
+        } else {
+          log(`Unknown option ignored: ${raw}`);
+        }
+    }
+  }
+
+  return { command, options };
+}
+
+function showHelp() {
+  console.log(`Dash manage script\n\nUsage:\n  node scripts/manage-dash.mjs <command> [options]\n\nCommands:\n  setup        Install dependencies and prepare backend/.env.\n  start        Launch the backend API (default command).\n\nOptions:\n  --mode <dev|prod>   Development (nodemon) or production build/start. Default: dev.\n  --port <number>     Preferred port for the backend (overrides PORT env).\n  --db-uri <string>   Update backend/.env with a MongoDB connection string.\n  --skip-install      Skip npm install during setup/start.\n  --init-db           Run the database initialisation script after setup/start.\n  --help, -h          Display this message.\n`);
+}
+
+/** Ensure backend/.env exists and is populated appropriately. */
+function ensureEnvConfig(dbUri) {
+  if (!existsSync(ENV_PATH)) {
+    if (!existsSync(ENV_EXAMPLE_PATH)) {
+      throw new Error('backend/.env is missing and backend/.env.example is not available.');
+    }
+    log('backend/.env not found. Creating from backend/.env.example.');
+    const example = readFileSync(ENV_EXAMPLE_PATH, 'utf8');
+    writeFileSync(ENV_PATH, example, 'utf8');
+  }
+
+  let envContent = readFileSync(ENV_PATH, 'utf8');
+  let updated = false;
+
+  if (dbUri) {
+    const sanitizedUri = dbUri.trim();
+    envContent = upsertEnvValue(envContent, 'DB_URI', sanitizedUri);
+    updated = true;
+    log(`Updated DB_URI in backend/.env to ${sanitizedUri}`);
+  }
+
+  const secretMatch = envContent.match(/^JWT_SECRET=(.*)$/m);
+  const currentSecret = secretMatch ? secretMatch[1].trim() : '';
+  if (!currentSecret || currentSecret.toLowerCase() === 'changeme') {
+    const newSecret = crypto.randomBytes(48).toString('base64');
+    envContent = upsertEnvValue(envContent, 'JWT_SECRET', newSecret);
+    updated = true;
+    log('Generated secure JWT_SECRET and stored it in backend/.env');
+  } else {
+    log('Existing JWT_SECRET detected; leaving unchanged.');
+  }
+
+  if (updated) {
+    writeFileSync(ENV_PATH, normalizeNewlines(envContent), 'utf8');
+  }
+}
+
+function normalizeNewlines(text) {
+  return text.replace(/\r?\n/g, '\n');
+}
+
+function upsertEnvValue(content, key, value) {
+  const pattern = new RegExp(`^${key}=.*$`, 'm');
+  if (pattern.test(content)) {
+    return content.replace(pattern, `${key}=${value}`);
+  }
+  const separator = content.endsWith('\n') ? '' : '\n';
+  return `${content}${separator}${key}=${value}\n`;
+}
+
+async function handleSetup(options) {
+  log('Starting Dash setup sequence.');
+  ensureEnvConfig(options.dbUri);
+  if (!options.skipInstall) {
+    await runCommand('npm', ['install']);
+  } else {
+    log('Skipping npm install as requested.');
+  }
+  if (options.initDb) {
+    await runCommand('npm', ['run', 'db:init', '--prefix', 'backend']);
+  }
+  log('Setup sequence complete.');
+}
+
+async function handleStart(options) {
+  log(`Starting Dash backend in ${options.mode} mode.`);
+  ensureEnvConfig(options.dbUri);
+  if (!options.skipInstall && !existsSync(resolve(ROOT_DIR, 'node_modules'))) {
+    log('Node modules missing; installing before launch.');
+    await runCommand('npm', ['install']);
+  } else if (!options.skipInstall) {
+    log('Dependencies already installed; skipping npm install.');
+  } else {
+    log('Skipping dependency installation prior to start.');
+  }
+
+  const env = { ...process.env };
+  if (options.port) {
+    env.PORT = String(options.port);
+    log(`Will request backend port ${options.port}.`);
+  }
+
+  if (options.mode === 'prod' || options.mode === 'production') {
+    env.NODE_ENV = 'production';
+    await runCommand('npm', ['run', 'build', '--prefix', 'backend'], { env });
+    await runCommand('npm', ['start', '--prefix', 'backend'], { env });
+  } else if (options.mode === 'dev' || options.mode === 'development') {
+    env.NODE_ENV = 'development';
+    await runCommand('npm', ['run', 'dev', '--prefix', 'backend'], { env });
+  } else {
+    throw new Error(`Unknown mode: ${options.mode}. Use dev or prod.`);
+  }
+
+  if (options.initDb) {
+    await runCommand('npm', ['run', 'db:init', '--prefix', 'backend'], { env });
+  }
+}
+
+async function main() {
+  const { command, options } = parseArguments(process.argv.slice(2));
+
+  if (options.help) {
+    showHelp();
+    return;
+  }
+
+  try {
+    switch (command) {
+      case 'setup':
+        await handleSetup(options);
+        break;
+      case 'start':
+        await handleStart(options);
+        break;
+      default:
+        log(`Unknown command: ${command}`);
+        showHelp();
+        process.exitCode = 1;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(`Fatal error: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a cross-platform `scripts/manage-dash.mjs` helper to prepare configuration, install dependencies, and launch the backend with logging
- wire helper into the root npm scripts for easier invocation
- rewrite the README to clearly separate one-time setup from repeatable run steps for Windows and Linux users

## Testing
- node scripts/manage-dash.mjs --help

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c052fb1c83289f60e4affa1109d7)