### PR TITLE
Improve setup diagnostics and helper accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ After installation, verify versions:
   mongod --version
   ```
 
+If `mongod` is reported as "not recognized" (Windows) or "command not found"
+(*nix), install MongoDB Community Server from
+https://www.mongodb.com/try/download/community or use your package manager
+(`sudo apt install mongodb` on Debian/Ubuntu). Alternatively, start a container
+with `docker run -d --name mongo -p 27017:27017 mongo:6` to provision a local
+database instantly.
+
 ---
 
 ## 1. One-time project setup
@@ -55,6 +62,10 @@ After installation, verify versions:
      ```bash
      node scripts/manage-dash.mjs setup --db-uri "mongodb://localhost:27017/dash"
      ```
+
+   > Working inside `backend/`? Run the same command without changing folders:
+   > `node scripts/manage-dash.mjs ...`. A proxy script forwards to the root
+   > helper automatically.
 
    Advanced flags:
    - `--skip-install` if you have already run `npm install`.

--- a/backend/scripts/manage-dash.mjs
+++ b/backend/scripts/manage-dash.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview Backend-local proxy for the Dash lifecycle helper.
+ *
+ * PURPOSE
+ * -------
+ * Allows developers who are working from the `backend/` directory to execute the
+ * standard `node scripts/manage-dash.mjs` command without navigating back to the
+ * repository root. The proxy simply re-invokes the root helper script, passing
+ * along every CLI argument untouched.
+ *
+ * STRUCTURE
+ * ---------
+ * - Resolve the repository root relative to this file.
+ * - Spawn a child Node.js process targeting the canonical helper script under
+ *   `../scripts/manage-dash.mjs`.
+ * - Pipe stdio through so logging and prompts behave exactly as they do when the
+ *   root script is executed directly.
+ *
+ * USAGE
+ * -----
+ * Execute from the backend folder just as you would from the root:
+ *   node scripts/manage-dash.mjs setup --db-uri "mongodb://localhost:27017/dash"
+ */
+
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootManageScript = resolve(__dirname, '../../scripts/manage-dash.mjs');
+
+const child = spawn(process.argv[0], [rootManageScript, ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  env: process.env,
+  shell: process.platform === 'win32'
+});
+
+child.on('exit', code => {
+  process.exit(code ?? 0);
+});
+
+child.on('error', error => {
+  console.error('Unable to delegate to the root manage script.', error);
+  process.exit(1);
+});

--- a/scripts/manage-dash.mjs
+++ b/scripts/manage-dash.mjs
@@ -29,7 +29,7 @@
  *   auto-generates a secure JWT secret when missing or left as the placeholder.
  */
 
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -100,6 +100,45 @@ function runCommand(command, args, options = {}) {
       }
     });
   });
+}
+
+/**
+ * Probe for the MongoDB server binary and emit actionable guidance when it is missing.
+ *
+ * The setup script cannot install MongoDB automatically, so we surface an
+ * easy-to-follow message for Windows and Linux / Raspberry Pi users. Returning a
+ * boolean allows callers to decide whether the absence should be fatal or only a
+ * warning (for example when connecting to a remote cluster).
+ */
+function reportMongoBinaryPresence() {
+  const probe = spawnSync('mongod', ['--version'], {
+    shell: process.platform === 'win32',
+    env: process.env,
+    encoding: 'utf8'
+  });
+
+  if (probe.error || probe.status !== 0) {
+    log('MongoDB server binary (mongod) not detected on PATH.');
+    const windowsHelp = 'Install MongoDB Community Server from https://www.mongodb.com/try/download/community '
+      + 'or run "docker run -d --name mongo -p 27017:27017 mongo:6" via Docker Desktop.';
+    const linuxHelp = 'Install MongoDB using your package manager (e.g. "sudo apt install mongodb"), '
+      + 'or run "docker run -d --name mongo -p 27017:27017 mongo:6" if Docker is available.';
+    const guidance = process.platform === 'win32' ? windowsHelp : linuxHelp;
+    log(guidance);
+    return false;
+  }
+
+  const combinedOutput = `${probe.stdout}${probe.stderr}`;
+  const versionLine = combinedOutput
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .find(line => line.toLowerCase().includes('db version'));
+  if (versionLine) {
+    log(`Confirmed MongoDB availability: ${versionLine}`);
+  } else {
+    log('Confirmed MongoDB availability via "mongod --version".');
+  }
+  return true;
 }
 
 /** Parse CLI arguments into command + options. */
@@ -210,6 +249,10 @@ function upsertEnvValue(content, key, value) {
 
 async function handleSetup(options) {
   log('Starting Dash setup sequence.');
+  const hasMongo = reportMongoBinaryPresence();
+  if (!hasMongo) {
+    log('Continuing setup; database-dependent commands will fail until MongoDB is installed or an external cluster is configured.');
+  }
   ensureEnvConfig(options.dbUri);
   if (!options.skipInstall) {
     await runCommand('npm', ['install']);
@@ -224,6 +267,10 @@ async function handleSetup(options) {
 
 async function handleStart(options) {
   log(`Starting Dash backend in ${options.mode} mode.`);
+  const hasMongo = reportMongoBinaryPresence();
+  if (!hasMongo) {
+    log('Backend start will proceed, but expect connection failures unless DB_URI targets a reachable MongoDB instance.');
+  }
   ensureEnvConfig(options.dbUri);
   if (!options.skipInstall && !existsSync(resolve(ROOT_DIR, 'node_modules'))) {
     log('Node modules missing; installing before launch.');


### PR DESCRIPTION
## Summary
- add a backend-local proxy so `node scripts/manage-dash.mjs` works when run from the backend directory
- enhance the helper script with MongoDB availability checks and actionable installation guidance
- document MongoDB installation troubleshooting and the new backend proxy in the root README

## Testing
- node scripts/manage-dash.mjs setup --skip-install
- (from backend/) node scripts/manage-dash.mjs setup --skip-install

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c308713c8328b15b42d2f4049649)